### PR TITLE
[FEAT] 다른 도메인 작업을 위한 사용자 도메인 기초 작업

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,6 @@ out/
 ### Custom ###
 db_dev.mv.db
 db_dev.trace.db
+.DS_Store
 
 logs/

--- a/src/main/java/com/ll/playon/domain/member/MemberRepository.java
+++ b/src/main/java/com/ll/playon/domain/member/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.ll.playon.domain.member;
+
+import com.ll.playon.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/ll/playon/domain/member/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/MemberService.java
@@ -1,0 +1,17 @@
+package com.ll.playon.domain.member;
+
+import com.ll.playon.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member findById(Long id){
+        // TODO : 예외 발생
+        return memberRepository.findById(id).get();
+    }
+}

--- a/src/main/java/com/ll/playon/domain/member/MemberSteamDataRepository.java
+++ b/src/main/java/com/ll/playon/domain/member/MemberSteamDataRepository.java
@@ -1,0 +1,7 @@
+package com.ll.playon.domain.member;
+
+import com.ll.playon.domain.member.entity.MemberSteamData;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberSteamDataRepository extends JpaRepository<MemberSteamData, Long> {
+}

--- a/src/main/java/com/ll/playon/domain/member/entity/Gender.java
+++ b/src/main/java/com/ll/playon/domain/member/entity/Gender.java
@@ -1,0 +1,5 @@
+package com.ll.playon.domain.member.entity;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/ll/playon/domain/member/entity/Member.java
+++ b/src/main/java/com/ll/playon/domain/member/entity/Member.java
@@ -1,0 +1,47 @@
+package com.ll.playon.domain.member.entity;
+
+import com.ll.playon.global.jpa.entity.BaseTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Member extends BaseTime {
+    @Column(unique = true, nullable = false)
+    private Long steamId;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    private String profile_img;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean is_deleted = false;
+
+    private LocalDateTime lastLoginAt;
+
+    // TODO : 회원가입 확정 안되서 일단 기본값 처리
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private PlayStyle play_style = PlayStyle.CASUAL;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private Gender gender = Gender.MALE;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private PreferredGenres preferred_genres = PreferredGenres.RPG;
+}

--- a/src/main/java/com/ll/playon/domain/member/entity/Member.java
+++ b/src/main/java/com/ll/playon/domain/member/entity/Member.java
@@ -1,13 +1,12 @@
 package com.ll.playon.domain.member.entity;
 
 import com.ll.playon.global.jpa.entity.BaseTime;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
+import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -28,6 +27,11 @@ public class Member extends BaseTime {
     private boolean is_deleted = false;
 
     private LocalDateTime lastLoginAt;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    @Builder.Default
+    private List<MemberSteamData> games = new ArrayList<>();
 
     // TODO : 회원가입 확정 안되서 일단 기본값 처리
     @Column(nullable = false)

--- a/src/main/java/com/ll/playon/domain/member/entity/MemberSteamData.java
+++ b/src/main/java/com/ll/playon/domain/member/entity/MemberSteamData.java
@@ -1,0 +1,19 @@
+package com.ll.playon.domain.member.entity;
+
+import com.ll.playon.global.jpa.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberSteamData extends BaseEntity {
+
+    private Long appId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Member member;
+}

--- a/src/main/java/com/ll/playon/domain/member/entity/PlayStyle.java
+++ b/src/main/java/com/ll/playon/domain/member/entity/PlayStyle.java
@@ -1,0 +1,5 @@
+package com.ll.playon.domain.member.entity;
+
+public enum PlayStyle {
+    CASUAL, HARDCORE, SPEEDRUN, COMPLETIONIST
+}

--- a/src/main/java/com/ll/playon/domain/member/entity/PreferredGenres.java
+++ b/src/main/java/com/ll/playon/domain/member/entity/PreferredGenres.java
@@ -1,0 +1,5 @@
+package com.ll.playon.domain.member.entity;
+
+public enum PreferredGenres {
+    FPS, RPG, MOBA, SPORTS, PUZZLE
+}

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -1,7 +1,9 @@
 package com.ll.playon.global.initData;
 
 import com.ll.playon.domain.member.MemberRepository;
+import com.ll.playon.domain.member.MemberSteamDataRepository;
 import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.member.entity.MemberSteamData;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,12 +13,16 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
 public class BaseInitData {
 
     private final MemberRepository memberRepository;
+    private final MemberSteamDataRepository memberSteamDataRepository;
 
     @Autowired
     @Lazy
@@ -31,8 +37,21 @@ public class BaseInitData {
 
     @Transactional
     public void makeSampleUsers() {
+        if(memberRepository.count() != 0) return;
+
         Member sampleMember = Member.builder()
                 .steamId(123L).username("sampleUser").lastLoginAt(LocalDateTime.now()).build();
         memberRepository.save(sampleMember);
+
+        List<Long> gameAppIds = Arrays.asList(2246340L, 2680010L, 2456740L);
+        List<MemberSteamData> games = new ArrayList<>();
+        for (Long appId : gameAppIds) {
+            MemberSteamData game = MemberSteamData.builder()
+                    .appId(appId).member(sampleMember).build();
+            games.add(game);
+        }
+        sampleMember.getGames().addAll(games);
+
+        memberSteamDataRepository.saveAll(games);
     }
 }

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -39,19 +39,33 @@ public class BaseInitData {
     public void makeSampleUsers() {
         if(memberRepository.count() != 0) return;
 
-        Member sampleMember = Member.builder()
-                .steamId(123L).username("sampleUser").lastLoginAt(LocalDateTime.now()).build();
-        memberRepository.save(sampleMember);
+        Member sampleMember1 = Member.builder()
+                .steamId(123L).username("sampleUser1").lastLoginAt(LocalDateTime.now()).build();
+        memberRepository.save(sampleMember1);
 
         List<Long> gameAppIds = Arrays.asList(2246340L, 2680010L, 2456740L);
         List<MemberSteamData> games = new ArrayList<>();
         for (Long appId : gameAppIds) {
             MemberSteamData game = MemberSteamData.builder()
-                    .appId(appId).member(sampleMember).build();
+                    .appId(appId).member(sampleMember1).build();
             games.add(game);
         }
-        sampleMember.getGames().addAll(games);
+        sampleMember1.getGames().addAll(games);
 
+        memberSteamDataRepository.saveAll(games);
+
+        Member sampleMember2 = Member.builder()
+                .steamId(456L).username("sampleUser2").lastLoginAt(LocalDateTime.now()).build();
+        memberRepository.save(sampleMember2);
+
+        sampleMember2.getGames().addAll(games);
+        memberSteamDataRepository.saveAll(games);
+
+        Member sampleMember3 = Member.builder()
+                .steamId(789L).username("sampleUser3").lastLoginAt(LocalDateTime.now()).build();
+        memberRepository.save(sampleMember3);
+
+        sampleMember3.getGames().addAll(games);
         memberSteamDataRepository.saveAll(games);
     }
 }

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -1,0 +1,38 @@
+package com.ll.playon.global.initData;
+
+import com.ll.playon.domain.member.MemberRepository;
+import com.ll.playon.domain.member.entity.Member;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+
+import java.time.LocalDateTime;
+
+@Configuration
+@RequiredArgsConstructor
+public class BaseInitData {
+
+    private final MemberRepository memberRepository;
+
+    @Autowired
+    @Lazy
+    private BaseInitData self;
+
+    @Bean
+    public ApplicationRunner baseInitDataApplicationRunner() {
+        return args -> {
+            self.makeSampleUsers();
+        };
+    }
+
+    @Transactional
+    public void makeSampleUsers() {
+        Member sampleMember = Member.builder()
+                .steamId(123L).username("sampleUser").lastLoginAt(LocalDateTime.now()).build();
+        memberRepository.save(sampleMember);
+    }
+}

--- a/src/main/java/com/ll/playon/global/jpa/entity/BaseEntity.java
+++ b/src/main/java/com/ll/playon/global/jpa/entity/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.ll.playon.global.jpa.entity;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Getter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@MappedSuperclass
+public class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Setter(AccessLevel.PROTECTED)
+    @EqualsAndHashCode.Include
+    private Long id;
+}

--- a/src/main/java/com/ll/playon/global/jpa/entity/BaseTime.java
+++ b/src/main/java/com/ll/playon/global/jpa/entity/BaseTime.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
-public class BaseTime {
+public class BaseTime extends BaseEntity{
     @CreatedDate
     @Setter(AccessLevel.PRIVATE)
     private LocalDateTime createdAt;

--- a/src/main/java/com/ll/playon/global/security/UserContext.java
+++ b/src/main/java/com/ll/playon/global/security/UserContext.java
@@ -1,0 +1,20 @@
+package com.ll.playon.global.security;
+
+import com.ll.playon.domain.member.MemberService;
+import com.ll.playon.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@RequestScope
+@Component
+@RequiredArgsConstructor
+public class UserContext {
+
+    private final MemberService memberService;
+
+    public Member getActor() {
+        // TODO : 실제 인증된 사용자 조회로 바꾸기
+        return memberService.findById(1L);
+    }
+}


### PR DESCRIPTION
## 작업 내용

1. 사용자 member 엔티티 및 샘플 사용자 생성 
(스팀id : 123, username : sampleUser1)
(스팀id : 456, username : sampleUser2)
(스팀id : 789, username : sampleUser3)

2. 사용자 스팀 데이터 memberSteamData 엔티티 및 샘플 데이터 생성
(각 샘플 사용자에게 게임 3개 추가)

3. getActor()

## /global/security/UserContext.java 의 getActor() 메서드

현재 인증된 사용자를 반환하는 로직으로 현재는 id 가 1인 샘플 사용자1을 반환합니다!

다른 도메인에서 현재 인증된 사용자가 필요한 경우가 많아서 먼저 작업 했습니다!

이후 나머지 로직들이 완성되면 해당 메서드도 실제 로직으로 수정 예정입니다!
