### PR TITLE
[FEAT] 스팀 없이 일반 회원 회원가입, 로그인, 스팀 연동

### DIFF
--- a/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
@@ -1,0 +1,39 @@
+package com.ll.playon.domain.member.controller;
+
+import com.ll.playon.domain.member.dto.MemberAuthRequest;
+import com.ll.playon.domain.member.dto.SignupMemberDetailResponse;
+import com.ll.playon.domain.member.service.MemberService;
+import com.ll.playon.global.response.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Tag(name = "MemberController")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/login")
+    @Transactional
+    @Operation(summary = "일반 회원 로그인")
+    public RsData<String> loginNoSteam(@RequestBody MemberAuthRequest req) {
+        memberService.loginNoSteam(req.username(), req.password());
+        return RsData.success(HttpStatus.OK, "성공");
+    }
+
+    @PostMapping("/signup")
+    @Transactional
+    @Operation(summary = "일반 회원 회원가입")
+    public RsData<SignupMemberDetailResponse> signupNoSteam(@RequestBody MemberAuthRequest req) {
+        return RsData.success(HttpStatus.OK, memberService.signupNoSteam(req.username(), req.password()));
+    }
+}

--- a/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.ll.playon.domain.member.service.MemberService;
 import com.ll.playon.global.response.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +26,7 @@ public class MemberController {
     @PostMapping("/login")
     @Transactional
     @Operation(summary = "일반 회원 로그인")
-    public RsData<String> loginNoSteam(@RequestBody MemberAuthRequest req) {
+    public RsData<String> loginNoSteam(@Valid @RequestBody MemberAuthRequest req) {
         memberService.loginNoSteam(req.username(), req.password());
         return RsData.success(HttpStatus.OK, "성공");
     }
@@ -33,7 +34,7 @@ public class MemberController {
     @PostMapping("/signup")
     @Transactional
     @Operation(summary = "일반 회원 회원가입")
-    public RsData<SignupMemberDetailResponse> signupNoSteam(@RequestBody MemberAuthRequest req) {
+    public RsData<SignupMemberDetailResponse> signupNoSteam(@Valid @RequestBody MemberAuthRequest req) {
         return RsData.success(HttpStatus.OK, memberService.signupNoSteam(req.username(), req.password()));
     }
 }

--- a/src/main/java/com/ll/playon/domain/member/controller/SteamAuthController.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/SteamAuthController.java
@@ -1,6 +1,7 @@
 package com.ll.playon.domain.member.controller;
 
 import com.ll.playon.domain.member.dto.SignupMemberDetailResponse;
+import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.member.service.SteamAuthService;
 import com.ll.playon.global.exceptions.ErrorCode;
 import com.ll.playon.global.response.RsData;
@@ -37,6 +38,11 @@ public class SteamAuthController {
     public RsData<Map<String, String>> signupRedirectToSteam() {
         return redirectToSteam("/signup");
     }
+    @GetMapping("/link")
+    @Operation(summary = "계정 연동 : 스팀 로그인 리다이렉트")
+    public RsData<Map<String, String>> linkRedirectToSteam() {
+        return redirectToSteam("/link");
+    }
     private RsData<Map<String, String>> redirectToSteam(String url) {
         final String authUrl = STEAM_OPENID_URL + "?openid.ns=http://specs.openid.net/auth/2.0"
                 + "&openid.claimed_id=http://specs.openid.net/auth/2.0/identifier_select"
@@ -55,19 +61,25 @@ public class SteamAuthController {
     @GetMapping("/callback/login")
     @Operation(summary = "스팀 인증 검증 및 로그인")
     public RsData<String> loginHandleSteamCallback(@RequestParam Map<String, String> params) {
-        handleSteamCallback(params, "login");
+        handleSteamCallback(params, "login", null);
         return RsData.success(HttpStatus.OK, "성공");
     }
     @GetMapping("/callback/signup")
     @Operation(summary = "스팀 인증 검증 및 회원가입")
     public RsData<SignupMemberDetailResponse> signupHandleSteamCallback(@RequestParam Map<String, String> params) {
-        return RsData.success(HttpStatus.OK, handleSteamCallback(params, "signup"));
+        return RsData.success(HttpStatus.OK, handleSteamCallback(params, "signup", null));
     }
-    public SignupMemberDetailResponse handleSteamCallback(@RequestParam Map<String, String> params, String method) {
+    @GetMapping("/callback/link")
+    @Operation(summary = "스팀 인증 검증 및 계정 연동")
+    public RsData<String> linkHandleSteamCallback(@RequestParam Map<String, String> params) {
+        handleSteamCallback(params, "link", userContext.getActor());
+        return RsData.success(HttpStatus.OK, "성공");
+    }
+    public SignupMemberDetailResponse handleSteamCallback(@RequestParam Map<String, String> params, String method, Member actor) {
         if (!"id_res".equals(params.get("openid.mode"))) {
             throw ErrorCode.EXTERNAL_API_UNEXPECTED_REQUEST.throwServiceException();
         }
-        return steamAuthService.validateSteamId(params, method);
+        return steamAuthService.validateSteamId(params, method, actor);
     }
 
     @PostMapping("/logout")

--- a/src/main/java/com/ll/playon/domain/member/controller/SteamAuthController.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/SteamAuthController.java
@@ -31,17 +31,17 @@ public class SteamAuthController {
     @GetMapping("/login")
     @Operation(summary = "로그인 : 스팀 로그인 리다이렉트")
     public RsData<Map<String, String>> loginRedirectToSteam() {
-        return redirectToSteam("/login");
+        return redirectToSteam(SteamRedirectPaths.LOGIN);
     }
     @GetMapping("/signup")
     @Operation(summary = "회원가입 : 스팀 로그인 리다이렉트")
     public RsData<Map<String, String>> signupRedirectToSteam() {
-        return redirectToSteam("/signup");
+        return redirectToSteam(SteamRedirectPaths.SIGNUP);
     }
     @GetMapping("/link")
     @Operation(summary = "계정 연동 : 스팀 로그인 리다이렉트")
     public RsData<Map<String, String>> linkRedirectToSteam() {
-        return redirectToSteam("/link");
+        return redirectToSteam(SteamRedirectPaths.LINK);
     }
     private RsData<Map<String, String>> redirectToSteam(String url) {
         final String authUrl = STEAM_OPENID_URL + "?openid.ns=http://specs.openid.net/auth/2.0"
@@ -61,25 +61,33 @@ public class SteamAuthController {
     @GetMapping("/callback/login")
     @Operation(summary = "스팀 인증 검증 및 로그인")
     public RsData<String> loginHandleSteamCallback(@RequestParam Map<String, String> params) {
-        handleSteamCallback(params, "login", null);
+        handleSteamCallbackWithoutActor(params, SteamRedirectPaths.LOGIN);
         return RsData.success(HttpStatus.OK, "성공");
     }
     @GetMapping("/callback/signup")
     @Operation(summary = "스팀 인증 검증 및 회원가입")
     public RsData<SignupMemberDetailResponse> signupHandleSteamCallback(@RequestParam Map<String, String> params) {
-        return RsData.success(HttpStatus.OK, handleSteamCallback(params, "signup", null));
+        return RsData.success(HttpStatus.OK, handleSteamCallbackWithoutActor(params, SteamRedirectPaths.SIGNUP));
     }
     @GetMapping("/callback/link")
     @Operation(summary = "스팀 인증 검증 및 계정 연동")
     public RsData<String> linkHandleSteamCallback(@RequestParam Map<String, String> params) {
-        handleSteamCallback(params, "link", userContext.getActor());
+        handleSteamCallbackWithActor(params, SteamRedirectPaths.LINK);
         return RsData.success(HttpStatus.OK, "성공");
     }
-    public SignupMemberDetailResponse handleSteamCallback(@RequestParam Map<String, String> params, String method, Member actor) {
+
+    public SignupMemberDetailResponse handleSteamCallbackWithoutActor(Map<String, String> params, String path) {
+        return handleSteamCallback(params, path, null);
+    }
+    public void handleSteamCallbackWithActor(Map<String, String> params, String path) {
+        handleSteamCallback(params, path, userContext.getActor());
+    }
+
+    public SignupMemberDetailResponse handleSteamCallback(@RequestParam Map<String, String> params, String path, Member actor) {
         if (!"id_res".equals(params.get("openid.mode"))) {
             throw ErrorCode.EXTERNAL_API_UNEXPECTED_REQUEST.throwServiceException();
         }
-        return steamAuthService.validateSteamId(params, method, actor);
+        return steamAuthService.validateSteamId(params, path, actor);
     }
 
     @PostMapping("/logout")

--- a/src/main/java/com/ll/playon/domain/member/controller/SteamRedirectPaths.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/SteamRedirectPaths.java
@@ -1,0 +1,7 @@
+package com.ll.playon.domain.member.controller;
+
+public class SteamRedirectPaths {
+    public static final String LOGIN = "/login";
+    public static final String SIGNUP = "/signup";
+    public static final String LINK = "/link";
+}

--- a/src/main/java/com/ll/playon/domain/member/dto/MemberAuthRequest.java
+++ b/src/main/java/com/ll/playon/domain/member/dto/MemberAuthRequest.java
@@ -1,0 +1,6 @@
+package com.ll.playon.domain.member.dto;
+
+public record MemberAuthRequest(
+    String username,
+    String password
+) {}

--- a/src/main/java/com/ll/playon/domain/member/dto/MemberAuthRequest.java
+++ b/src/main/java/com/ll/playon/domain/member/dto/MemberAuthRequest.java
@@ -1,6 +1,8 @@
 package com.ll.playon.domain.member.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record MemberAuthRequest(
-    String username,
-    String password
+    @NotBlank(message = "아이디를 입력하세요.") String username,
+    @NotBlank(message = "비밀번호를 입력하세요.") String password
 ) {}

--- a/src/main/java/com/ll/playon/domain/member/entity/Member.java
+++ b/src/main/java/com/ll/playon/domain/member/entity/Member.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Member extends BaseTime {
+    @Setter
     @Column(unique = true)
     private Long steamId;
 

--- a/src/main/java/com/ll/playon/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ll/playon/domain/member/repository/MemberRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByApiKey(String apiKey);
     Optional<Member> findBySteamId(Long steamId);
+
+    Optional<Member> findByUsername(String username);
 }

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -53,7 +53,7 @@ public class MemberService {
                 .username((String) payload.get("username"))
                 .role((Role) payload.get("role"))
                 .build();
-        parsedMember.changeMemberId((long) payload.get("id"));
+        parsedMember.changeMemberId(((Number)payload.get("id")).longValue());
 
         return parsedMember;
     }
@@ -159,4 +159,12 @@ public class MemberService {
         userContext.setLogin(member);
     }
 
+    public void steamLink(Long steamId, Member actor) {
+        Member targetMember = memberRepository.findById(actor.getId())
+                        .orElseThrow(ErrorCode.AUTHORIZATION_FAILED::throwServiceException);
+        targetMember.setSteamId(steamId);
+        memberRepository.save(targetMember);
+
+        saveUserGameList(steamAPI.getUserGames(steamId), targetMember);
+    }
 }

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -10,6 +10,7 @@ import com.ll.playon.global.exceptions.ErrorCode;
 import com.ll.playon.global.security.UserContext;
 import com.ll.playon.global.steamAPI.SteamAPI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 
@@ -25,6 +26,7 @@ public class MemberService {
     private final UserContext userContext;
     private final SteamAPI steamAPI;
     private final MemberSteamDataRepository memberSteamDataRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public Optional<Member> findById(Long id){
         return memberRepository.findById(id);
@@ -32,6 +34,10 @@ public class MemberService {
 
     public Optional<Member> findByApiKey(String apiKey) {
         return memberRepository.findByApiKey(apiKey);
+    }
+
+    public Optional<Member> findByUsername(String username) {
+        return memberRepository.findByUsername(username);
     }
 
     public String genAccessToken(Member user) {
@@ -59,6 +65,19 @@ public class MemberService {
         handleSuccessfulLogin(member);
     }
 
+    public void loginNoSteam(String username, String password) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(ErrorCode.USER_NOT_REGISTERED::throwServiceException);
+
+        // 비밀번호 확인
+        if (!passwordEncoder.matches(password, member.getPassword())) {
+            throw ErrorCode.PASSWORD_INCORRECT.throwServiceException();
+        }
+
+        // 성공
+        handleSuccessfulLogin(member);
+    }
+
     public SignupMemberDetailResponse steamSignup(Long steamId) {
         if (memberRepository.findBySteamId(steamId).isPresent()) {
             throw ErrorCode.USER_ALREADY_REGISTERED.throwServiceException();
@@ -73,17 +92,20 @@ public class MemberService {
                 member.getSkillLevel(), member.getGender());
     }
 
-    private void handleSuccessfulLogin(Member member) {
-        member.setLastLoginAt(LocalDateTime.now());
-        memberRepository.save(member);
+    public SignupMemberDetailResponse signupNoSteam(String username, String password) {
+        Optional<Member> memberOptional = memberRepository.findByUsername(username);
+        if(memberOptional.isPresent()) {
+            throw ErrorCode.USER_ALREADY_REGISTERED.throwServiceException();
+        }
 
-        // 쿠키 세팅
-        userContext.makeAuthCookies(member);
+        Member member = signup(username, password);
 
-        // 시큐리티 로그인
-        userContext.setLogin(member);
+        handleSuccessfulLogin(member);
+
+        return new SignupMemberDetailResponse(
+                member.getNickname(), member.getProfileImg(), member.getPlayStyle(),
+                member.getSkillLevel(), member.getGender());
     }
-
 
     private Member signup(Long steamId) {
         Map<String, String> profile = steamAPI.getUserProfile(steamId);
@@ -102,6 +124,18 @@ public class MemberService {
         return newMember;
     }
 
+    private Member signup(String username, String password) {
+        Member newMember = Member.builder()
+                .username(username)
+                .password(passwordEncoder.encode(password))
+                .role(Role.USER)
+                .nickname(username)
+                .build();
+        memberRepository.save(newMember);
+
+        return newMember;
+    }
+
     public void saveUserGameList(List<Long> gameList, Member member) {
         List<MemberSteamData> games = gameList.stream()
                 .map(appId -> MemberSteamData.builder()
@@ -113,4 +147,16 @@ public class MemberService {
         member.getGames().addAll(games);
         memberSteamDataRepository.saveAll(games);
     }
+
+    private void handleSuccessfulLogin(Member member) {
+        member.setLastLoginAt(LocalDateTime.now());
+        memberRepository.save(member);
+
+        // 쿠키 세팅
+        userContext.makeAuthCookies(member);
+
+        // 시큐리티 로그인
+        userContext.setLogin(member);
+    }
+
 }

--- a/src/main/java/com/ll/playon/domain/member/service/SteamAuthService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/SteamAuthService.java
@@ -1,6 +1,7 @@
 package com.ll.playon.domain.member.service;
 
 import com.ll.playon.domain.member.dto.SignupMemberDetailResponse;
+import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.global.exceptions.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
@@ -18,7 +19,7 @@ public class SteamAuthService {
     private final RestTemplate restTemplate;
     private final MemberService memberService;
 
-    public SignupMemberDetailResponse validateSteamId(Map<String, String> params, String method) {
+    public SignupMemberDetailResponse validateSteamId(Map<String, String> params, String method, Member actor) {
         String validationUrl = "https://steamcommunity.com/openid/login";
         String requestBody = buildValidationRequest(params);
 
@@ -35,8 +36,11 @@ public class SteamAuthService {
             if(method.equals("login")) {
                 memberService.steamLogin(steamUserId);
                 return null;
-            } else {
+            } else if(method.equals("signup")) {
                 return memberService.steamSignup(steamUserId);
+            } else {
+                memberService.steamLink(steamUserId, actor);
+                return null;
             }
         } else {
             throw ErrorCode.AUTHORIZATION_FAILED.throwServiceException();

--- a/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     AUTHORIZATION_FAILED(HttpStatus.UNAUTHORIZED, "인증이 실패하였습니다."),
     USER_NOT_REGISTERED(HttpStatus.NOT_FOUND, "가입되지 않은 사용자입니다."),
     USER_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 가입된 사용자입니다."),
+    PASSWORD_INCORRECT(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
 
     // Guild
     DUPLICATE_GUILD_NAME(HttpStatus.CONFLICT, "이미 존재하는 길드 이름입니다."),

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -1,16 +1,18 @@
 package com.ll.playon.global.initData;
 
-import com.ll.playon.domain.member.entity.enums.Role;
 import com.ll.playon.domain.guild.guild.entity.Guild;
-import com.ll.playon.domain.guild.guild.enums.*;
+import com.ll.playon.domain.guild.guild.enums.ActiveTime;
+import com.ll.playon.domain.guild.guild.enums.GameSkill;
+import com.ll.playon.domain.guild.guild.enums.GenderFilter;
+import com.ll.playon.domain.guild.guild.enums.PartyStyle;
 import com.ll.playon.domain.guild.guild.repository.GuildRepository;
 import com.ll.playon.domain.guild.guildMember.entity.GuildMember;
 import com.ll.playon.domain.guild.guildMember.enums.GuildRole;
 import com.ll.playon.domain.guild.guildMember.repository.GuildMemberRepository;
+import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.member.entity.enums.Role;
 import com.ll.playon.domain.member.repository.MemberRepository;
 import com.ll.playon.domain.member.service.MemberService;
-import com.ll.playon.domain.member.repository.MemberSteamDataRepository;
-import com.ll.playon.domain.member.entity.Member;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +20,7 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -28,10 +31,10 @@ import java.util.List;
 public class BaseInitData {
 
     private final MemberRepository memberRepository;
-    private final MemberSteamDataRepository memberSteamDataRepository;
     private final GuildRepository guildRepository;
     private final GuildMemberRepository guildMemberRepository;
     private final MemberService memberService;
+    private final PasswordEncoder passwordEncoder;
 
     @Autowired
     @Lazy
@@ -52,21 +55,23 @@ public class BaseInitData {
         Member sampleMember1 = Member.builder()
                 .steamId(123L).username("sampleUser1").lastLoginAt(LocalDateTime.now()).role(Role.USER).build();
         memberRepository.save(sampleMember1);
-
         List<Long> gameAppIds = Arrays.asList(2246340L, 2680010L, 2456740L);
         memberService.saveUserGameList(gameAppIds, sampleMember1);
 
         Member sampleMember2 = Member.builder()
                 .steamId(456L).username("sampleUser2").lastLoginAt(LocalDateTime.now()).role(Role.USER).build();
         memberRepository.save(sampleMember2);
-
         memberService.saveUserGameList(gameAppIds, sampleMember2);
 
         Member sampleMember3 = Member.builder()
                 .steamId(789L).username("sampleUser3").lastLoginAt(LocalDateTime.now()).role(Role.USER).build();
         memberRepository.save(sampleMember3);
-
         memberService.saveUserGameList(gameAppIds, sampleMember3);
+
+        Member noSteamMember = Member.builder()
+                .username("noSteamMember").nickname("noSteamUser").password(passwordEncoder.encode("noSteam123"))
+                .lastLoginAt(LocalDateTime.now()).role(Role.USER).build();
+        memberRepository.save(noSteamMember);
     }
 
     @Transactional

--- a/src/main/java/com/ll/playon/global/security/PasswordEncoderConfig.java
+++ b/src/main/java/com/ll/playon/global/security/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.ll.playon.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/test/java/com/ll/playon/domain/member/TestMemberHelper.java
+++ b/src/test/java/com/ll/playon/domain/member/TestMemberHelper.java
@@ -1,0 +1,31 @@
+package com.ll.playon.domain.member;
+
+import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.member.service.MemberService;
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@Component
+public class TestMemberHelper {
+
+    private final MemberService memberService;
+    private final MockMvc mvc;
+
+    public TestMemberHelper(MemberService memberService, MockMvc mvc) {
+        this.memberService = memberService;
+        this.mvc = mvc;
+    }
+
+    public ResultActions requestWithUserAuth(String username, MockHttpServletRequestBuilder request) throws Exception {
+        Member actor = memberService.findByUsername(username).get();
+        String actorAuthToken = memberService.genAccessToken(actor);
+
+        return mvc.perform(request
+                .header("Authorization", "Bearer " + actor.getApiKey() + " " + actorAuthToken)
+        ).andDo(print());
+    }
+}

--- a/src/test/java/com/ll/playon/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/ll/playon/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,167 @@
+package com.ll.playon.domain.member.controller;
+
+import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.member.service.MemberService;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+public class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("일반 회원 회원가입")
+    void noSteamSignup() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/api/auth/signup")
+                                .content("""
+                                        {
+                                            "username": "noSteamTestUser",
+                                            "password": "noSteam123"
+                                        }
+                                        """.stripIndent()
+                                )
+                                .contentType(
+                                        new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8)
+                                )
+                )
+                .andDo(print());
+
+        Member actor = memberService.findByUsername("noSteamTestUser").get();
+
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.nickname").value(actor.getNickname()));
+
+        resultActions.andExpect(
+                result -> {
+                    Cookie accessTokenCookie = result.getResponse().getCookie("accessToken");
+                    assertThat(accessTokenCookie.getValue()).isNotBlank();
+                    assertThat(accessTokenCookie.getPath()).isEqualTo("/");
+                    assertThat(accessTokenCookie.isHttpOnly()).isTrue();
+
+                    Cookie apiKeyCookie = result.getResponse().getCookie("apiKey");
+                    assertThat(apiKeyCookie.getValue()).isEqualTo(actor.getApiKey());
+                    assertThat(apiKeyCookie.getPath()).isEqualTo("/");
+                    assertThat(apiKeyCookie.isHttpOnly()).isTrue();
+                }
+        );
+    }
+
+    @Test
+    @DisplayName("일반 회원 로그인")
+    void noSteamLogin() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/api/auth/login")
+                                .content("""
+                                    {
+                                        "username": "noSteamMember",
+                                        "password": "noSteam123"
+                                    }
+                                    """.stripIndent()
+                                )
+                                .contentType(
+                                        new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8)
+                                )
+                )
+                .andDo(print());
+
+        Member actor = memberService.findByUsername("noSteamMember").get();
+
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(status().isOk());
+
+        resultActions.andExpect(
+                result -> {
+                    Cookie accessTokenCookie = result.getResponse().getCookie("accessToken");
+                    assertThat(accessTokenCookie.getValue()).isNotBlank();
+                    assertThat(accessTokenCookie.getPath()).isEqualTo("/");
+                    assertThat(accessTokenCookie.isHttpOnly()).isTrue();
+
+                    Cookie apiKeyCookie = result.getResponse().getCookie("apiKey");
+                    assertThat(apiKeyCookie.getValue()).isEqualTo(actor.getApiKey());
+                    assertThat(apiKeyCookie.getPath()).isEqualTo("/");
+                    assertThat(apiKeyCookie.isHttpOnly()).isTrue();
+                }
+        );
+    }
+
+    @Test
+    @DisplayName("일반회원 회원가입 실패")
+    void noSteamSignupFail() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/api/auth/signup")
+                                .content("""
+                                    {
+                                        "username": "noSteamMember",
+                                        "password": "noSteam123"
+                                    }
+                                    """.stripIndent()
+                                )
+                                .contentType(
+                                        new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8)
+                                )
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("일반회원 로그인 실패")
+    void noSteamLoginFail() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/api/auth/login")
+                                .content("""
+                                    {
+                                        "username": "noSteamTestUser",
+                                        "password": "noSteam123"
+                                    }
+                                    """.stripIndent()
+                                )
+                                .contentType(
+                                        new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8)
+                                )
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/ll/playon/domain/member/controller/SteamAuthTest.java
+++ b/src/test/java/com/ll/playon/domain/member/controller/SteamAuthTest.java
@@ -1,5 +1,7 @@
 package com.ll.playon.domain.member.controller;
 
+import com.ll.playon.domain.member.TestMemberHelper;
+import com.ll.playon.domain.member.repository.MemberSteamDataRepository;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -13,6 +15,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -21,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -39,6 +43,12 @@ public class SteamAuthTest {
     private RestTemplate restTemplate;
 
     private MockRestServiceServer mockServer;
+
+    @Autowired
+    private TestMemberHelper testMemberHelper;
+
+    @Autowired
+    private MemberSteamDataRepository memberSteamDataRepository;
 
     @Value("${custom.steam.apikey}")
     private String apikey;
@@ -189,6 +199,38 @@ public class SteamAuthTest {
         resultActions.andExpect(status().isNotFound());
 
         // mock 서버 검증 (API 가 제대로 호출되었는지 확인)
+        mockServer.verify();
+    }
+
+    @Test
+    @DisplayName("스팀 계정 연동 성공 테스트, noSteamMember")
+    void linkNoSteamMember() throws Exception {
+        long initCount = memberSteamDataRepository.count();
+        // 가짜 API 응답 설정
+        mockServer.expect(requestTo("https://steamcommunity.com/openid/login"))
+                .andRespond(withSuccess("is_valid:true", MediaType.TEXT_PLAIN));
+
+        // 가짜 게임 리스트 응답 설정
+        String fakeGameListResponse = "{ \"response\": { \"games\": [ { \"appid\": 123 }, { \"appid\": 456 } ] } }";
+        mockServer.expect(requestTo(String.format("https://api.steampowered.com/IPlayerService/GetOwnedGames/v1/?key=%s&steamid=1234",apikey)))
+                .andRespond(withSuccess(fakeGameListResponse, MediaType.APPLICATION_JSON));
+
+        // 컨트롤러 호출
+        MockHttpServletRequestBuilder request = get("/api/auth/steam/callback/link")
+                        .params(new LinkedMultiValueMap<>(Collections.singletonMap("openid.mode", List.of("id_res"))))
+                        .params(new LinkedMultiValueMap<>(Collections.singletonMap("openid.claimed_id", List.of("https://steamcommunity.com/openid/id/1234"))))
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        ResultActions resultActions = testMemberHelper.requestWithUserAuth("noSteamMember", request);
+
+        // 응답 상태 코드 검증
+        resultActions.andExpect(status().isOk());
+
+        // count가 3 증가했는지 검증
+        long finalCount = memberSteamDataRepository.count();
+        assertEquals(initCount + 2, finalCount);
+
+        // mock 서버 검증 (API가 제대로 호출되었는지 확인)
         mockServer.verify();
     }
 }


### PR DESCRIPTION
## 작업 내용

이후 테스트 및 시연을 위해 스팀 계정이 아닌

일반적인 아이디와 비밀번호를 입력하는 회원가입과 로그인 방법을 구현하였습니다.

또한 일반 계정이 스팀 계정을 연동하는 API 도 구현하였습니다.

<br>

## TestMemberHelper.java

테스트시 인증 작업을 돕는 메서드를 만들었습니다.

~~~
ResultActions resultActions = testMemberHelper.requestWithUserAuth("noSteamMember", request);
~~~

와 같이 사용하면 해당 username 을 가진 사용자의

JWT 토큰값과 apikey 가 요청의 헤더에 부착되어 요청이 해당 사용자가 보낸 것으로 인증됩니다.

<br>

## 남은 작업 내용

- 회원 정보 수정 ( 프론트에서 회원가입 두번째 단계로 사용됨)

- 회원 탈퇴

- 닉네임으로 회원 조회