### PR TITLE
[FEAT] 사용자 상세 조회 ( + 소유 게임), 닉네임으로 사용자 목록 조회

### DIFF
--- a/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
@@ -4,7 +4,6 @@ import com.ll.playon.domain.member.dto.GetMembersResponse;
 import com.ll.playon.domain.member.dto.MemberAuthRequest;
 import com.ll.playon.domain.member.dto.MemberDetailDto;
 import com.ll.playon.domain.member.dto.MemberProfileResponse;
-import com.ll.playon.domain.member.dto.SignupMemberDetailResponse;
 import com.ll.playon.domain.member.service.MemberService;
 import com.ll.playon.global.response.RsData;
 import com.ll.playon.global.security.UserContext;

--- a/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
@@ -2,6 +2,8 @@ package com.ll.playon.domain.member.controller;
 
 import com.ll.playon.domain.member.dto.MemberAuthRequest;
 import com.ll.playon.domain.member.dto.MemberDetailDto;
+import com.ll.playon.domain.member.dto.MemberProfileResponse;
+import com.ll.playon.domain.member.dto.SignupMemberDetailResponse;
 import com.ll.playon.domain.member.service.MemberService;
 import com.ll.playon.global.response.RsData;
 import com.ll.playon.global.security.UserContext;
@@ -52,4 +54,11 @@ public class MemberController {
         memberService.deactivateMember(userContext.getActor());
         return RsData.success(HttpStatus.OK, "성공적으로 탈퇴되었습니다.");
     }
+
+    @GetMapping("/me")
+    @Operation(summary = "내 정보")
+    public RsData<MemberProfileResponse> getMyProfile() {
+        return RsData.success(HttpStatus.OK, memberService.me(userContext.getActor()));
+    }
+
 }

--- a/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.ll.playon.domain.member.controller;
 
+import com.ll.playon.domain.member.dto.GetMembersResponse;
 import com.ll.playon.domain.member.dto.MemberAuthRequest;
 import com.ll.playon.domain.member.dto.MemberDetailDto;
 import com.ll.playon.domain.member.dto.MemberProfileResponse;
@@ -14,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/members")
@@ -59,6 +62,11 @@ public class MemberController {
     @Operation(summary = "내 정보")
     public RsData<MemberProfileResponse> getMyProfile() {
         return RsData.success(HttpStatus.OK, memberService.me(userContext.getActor()));
+    }
+
+    @GetMapping("/nickname")
+    public RsData<List<GetMembersResponse>> getMembersByNickname(@RequestParam String nickname) {
+        return RsData.success(HttpStatus.OK, memberService.findByNickname(nickname));
     }
 
 }

--- a/src/main/java/com/ll/playon/domain/member/dto/GameDetailDto.java
+++ b/src/main/java/com/ll/playon/domain/member/dto/GameDetailDto.java
@@ -1,0 +1,10 @@
+package com.ll.playon.domain.member.dto;
+
+import java.util.List;
+
+public record GameDetailDto(
+        Long appId,
+        String name,
+        String img,
+        List<String> genres
+) {}

--- a/src/main/java/com/ll/playon/domain/member/dto/GetMembersResponse.java
+++ b/src/main/java/com/ll/playon/domain/member/dto/GetMembersResponse.java
@@ -1,0 +1,7 @@
+package com.ll.playon.domain.member.dto;
+
+public record GetMembersResponse(
+        Long steamId,
+        String username,
+        String profileImg
+) {}

--- a/src/main/java/com/ll/playon/domain/member/dto/MemberOwnedGamesDto.java
+++ b/src/main/java/com/ll/playon/domain/member/dto/MemberOwnedGamesDto.java
@@ -1,7 +1,0 @@
-package com.ll.playon.domain.member.dto;
-
-import java.util.List;
-
-public record MemberOwnedGamesDto(
-        List<GameDetailDto> ownedGames
-) {}

--- a/src/main/java/com/ll/playon/domain/member/dto/MemberOwnedGamesDto.java
+++ b/src/main/java/com/ll/playon/domain/member/dto/MemberOwnedGamesDto.java
@@ -1,0 +1,7 @@
+package com.ll.playon.domain.member.dto;
+
+import java.util.List;
+
+public record MemberOwnedGamesDto(
+        List<GameDetailDto> ownedGames
+) {}

--- a/src/main/java/com/ll/playon/domain/member/dto/MemberProfileResponse.java
+++ b/src/main/java/com/ll/playon/domain/member/dto/MemberProfileResponse.java
@@ -1,6 +1,8 @@
 package com.ll.playon.domain.member.dto;
 
+import java.util.List;
+
 public record MemberProfileResponse(
         ProfileMemberDetailDto memberDetail,
-        MemberOwnedGamesDto ownedGames
+        List<GameDetailDto> ownedGames
 ) {}

--- a/src/main/java/com/ll/playon/domain/member/dto/MemberProfileResponse.java
+++ b/src/main/java/com/ll/playon/domain/member/dto/MemberProfileResponse.java
@@ -1,0 +1,6 @@
+package com.ll.playon.domain.member.dto;
+
+public record MemberProfileResponse(
+        ProfileMemberDetailDto memberDetail,
+        MemberOwnedGamesDto ownedGames
+) {}

--- a/src/main/java/com/ll/playon/domain/member/dto/ProfileMemberDetailDto.java
+++ b/src/main/java/com/ll/playon/domain/member/dto/ProfileMemberDetailDto.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 public record ProfileMemberDetailDto(
         Long steamId,
         String username,
+        String nickname,
         String profileImg,
         LocalDateTime lastLoginAt,
         PlayStyle playStyle,

--- a/src/main/java/com/ll/playon/domain/member/dto/ProfileMemberDetailDto.java
+++ b/src/main/java/com/ll/playon/domain/member/dto/ProfileMemberDetailDto.java
@@ -1,0 +1,19 @@
+package com.ll.playon.domain.member.dto;
+
+import com.ll.playon.domain.member.entity.enums.Gender;
+import com.ll.playon.domain.member.entity.enums.PlayStyle;
+import com.ll.playon.domain.member.entity.enums.PreferredGenres;
+import com.ll.playon.domain.member.entity.enums.SkillLevel;
+
+import java.time.LocalDateTime;
+
+public record ProfileMemberDetailDto(
+        Long steamId,
+        String username,
+        String profileImg,
+        LocalDateTime lastLoginAt,
+        PlayStyle playStyle,
+        SkillLevel skillLevel,
+        Gender gender,
+        PreferredGenres preferredGenres
+){}

--- a/src/main/java/com/ll/playon/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ll/playon/domain/member/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package com.ll.playon.domain.member.repository;
 import com.ll.playon.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -10,4 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findBySteamId(Long steamId);
 
     Optional<Member> findByUsername(String username);
+
+    List<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/ll/playon/domain/member/repository/MemberSteamDataRepository.java
+++ b/src/main/java/com/ll/playon/domain/member/repository/MemberSteamDataRepository.java
@@ -3,5 +3,8 @@ package com.ll.playon.domain.member.repository;
 import com.ll.playon.domain.member.entity.MemberSteamData;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MemberSteamDataRepository extends JpaRepository<MemberSteamData, Long> {
+    List<MemberSteamData> findAllByMemberId(Long id);
 }

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -212,7 +212,7 @@ public class MemberService {
 
         // 사용자 정보 조회 후 Dto 에 담기
         ProfileMemberDetailDto profileMemberDetailDto = new ProfileMemberDetailDto(
-                member.getSteamId(), member.getUsername(), member.getProfileImg(),
+                member.getSteamId(), member.getUsername(), member.getNickname(), member.getProfileImg(),
                 member.getLastLoginAt(), member.getPlayStyle(), member.getSkillLevel(),
                 member.getGender(), member.getPreferredGenres()
         );
@@ -221,13 +221,13 @@ public class MemberService {
         List<MemberSteamData> gamesList = memberSteamDataRepository.findAllByMemberId(actor.getId());
 
         // 게임 상세 (이름, 장르, 이미지) 조회 후 Dto 에 담기
-        MemberOwnedGamesDto memberOwnedGamesDto = getMemberOwnedGamesDto(gamesList);
+        List<GameDetailDto> memberOwnedGamesDto = getMemberOwnedGamesDto(gamesList);
 
         // 모든 정보 MemberProfileResponse 에 담기
         return new MemberProfileResponse(profileMemberDetailDto, memberOwnedGamesDto);
     }
 
-    private static MemberOwnedGamesDto getMemberOwnedGamesDto(List<MemberSteamData> gamesList) {
+    private static List<GameDetailDto> getMemberOwnedGamesDto(List<MemberSteamData> gamesList) {
         List<GameDetailDto> gameDetailDtoList = new ArrayList<>();
         for(MemberSteamData game : gamesList) {
             // TODO : 게임 데이터 작업 후 수정
@@ -237,7 +237,7 @@ public class MemberService {
             GameDetailDto gameDetail = new GameDetailDto(game.getAppId(), gameName, gameImg, gameGenres);
             gameDetailDtoList.add(gameDetail);
         }
-        return new MemberOwnedGamesDto(gameDetailDtoList);
+        return gameDetailDtoList;
     }
 
     public List<GetMembersResponse> findByNickname(String nickname) {

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -1,7 +1,6 @@
 package com.ll.playon.domain.member.service;
 
 import com.ll.playon.domain.member.dto.*;
-import com.ll.playon.domain.member.dto.MemberDetailDto;
 import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.member.entity.MemberSteamData;
 import com.ll.playon.domain.member.entity.enums.Role;
@@ -16,14 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -220,11 +212,8 @@ public class MemberService {
         // 보유한 게임 목록 조회
         List<MemberSteamData> gamesList = memberSteamDataRepository.findAllByMemberId(actor.getId());
 
-        // 게임 상세 (이름, 장르, 이미지) 조회 후 Dto 에 담기
-        List<GameDetailDto> memberOwnedGamesDto = getMemberOwnedGamesDto(gamesList);
-
         // 모든 정보 MemberProfileResponse 에 담기
-        return new MemberProfileResponse(profileMemberDetailDto, memberOwnedGamesDto);
+        return new MemberProfileResponse(profileMemberDetailDto, getMemberOwnedGamesDto(gamesList));
     }
 
     private static List<GameDetailDto> getMemberOwnedGamesDto(List<MemberSteamData> gamesList) {

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -240,4 +240,10 @@ public class MemberService {
         return new MemberOwnedGamesDto(gameDetailDtoList);
     }
 
+    public List<GetMembersResponse> findByNickname(String nickname) {
+        return memberRepository.findByNickname(nickname).stream()
+                .map(member ->
+                        new GetMembersResponse(member.getSteamId(), member.getUsername(), member.getProfileImg()))
+                .toList();
+    }
 }

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.ll.playon.domain.member.service;
 
+import com.ll.playon.domain.member.dto.*;
 import com.ll.playon.domain.member.dto.MemberDetailDto;
 import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.member.entity.MemberSteamData;
@@ -15,6 +16,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -200,4 +205,39 @@ public class MemberService {
                 .isDeleted(true)
                 .build());
     }
+
+    public MemberProfileResponse me(Member actor) {
+        Member member = memberRepository.findById(actor.getId())
+                .orElseThrow(ErrorCode.AUTHORIZATION_FAILED::throwServiceException);
+
+        // 사용자 정보 조회 후 Dto 에 담기
+        ProfileMemberDetailDto profileMemberDetailDto = new ProfileMemberDetailDto(
+                member.getSteamId(), member.getUsername(), member.getProfileImg(),
+                member.getLastLoginAt(), member.getPlayStyle(), member.getSkillLevel(),
+                member.getGender(), member.getPreferredGenres()
+        );
+
+        // 보유한 게임 목록 조회
+        List<MemberSteamData> gamesList = memberSteamDataRepository.findAllByMemberId(actor.getId());
+
+        // 게임 상세 (이름, 장르, 이미지) 조회 후 Dto 에 담기
+        MemberOwnedGamesDto memberOwnedGamesDto = getMemberOwnedGamesDto(gamesList);
+
+        // 모든 정보 MemberProfileResponse 에 담기
+        return new MemberProfileResponse(profileMemberDetailDto, memberOwnedGamesDto);
+    }
+
+    private static MemberOwnedGamesDto getMemberOwnedGamesDto(List<MemberSteamData> gamesList) {
+        List<GameDetailDto> gameDetailDtoList = new ArrayList<>();
+        for(MemberSteamData game : gamesList) {
+            // TODO : 게임 데이터 작업 후 수정
+            String gameName = "gameName";
+            String gameImg = "gameImg";
+            List<String> gameGenres = List.of("genre1","genre2");
+            GameDetailDto gameDetail = new GameDetailDto(game.getAppId(), gameName, gameImg, gameGenres);
+            gameDetailDtoList.add(gameDetail);
+        }
+        return new MemberOwnedGamesDto(gameDetailDtoList);
+    }
+
 }

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -55,18 +55,18 @@ public class BaseInitData {
         }
 
         Member sampleMember1 = Member.builder()
-                .steamId(123L).username("sampleUser1").nickname("sampleUser1").lastLoginAt(LocalDateTime.now()).role(Role.USER).build();
+                .steamId(123L).username("sampleUser1").nickname("sampleUser").lastLoginAt(LocalDateTime.now()).role(Role.USER).build();
         memberRepository.save(sampleMember1);
         List<Long> gameAppIds = Arrays.asList(2246340L, 2680010L, 2456740L);
         memberService.saveUserGameList(gameAppIds, sampleMember1);
 
         Member sampleMember2 = Member.builder()
-                .steamId(456L).username("sampleUser2").lastLoginAt(LocalDateTime.now()).role(Role.USER).build();
+                .steamId(456L).username("sampleUser2").nickname("sampleUser").lastLoginAt(LocalDateTime.now()).role(Role.USER).build();
         memberRepository.save(sampleMember2);
         memberService.saveUserGameList(gameAppIds, sampleMember2);
 
         Member sampleMember3 = Member.builder()
-                .steamId(789L).username("sampleUser3").lastLoginAt(LocalDateTime.now()).role(Role.USER).build();
+                .steamId(789L).username("sampleUser3").nickname("sampleUser").lastLoginAt(LocalDateTime.now()).role(Role.USER).build();
         memberRepository.save(sampleMember3);
 
         memberService.saveUserGameList(gameAppIds, sampleMember3);

--- a/src/test/java/com/ll/playon/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/ll/playon/domain/member/controller/MemberControllerTest.java
@@ -2,6 +2,9 @@ package com.ll.playon.domain.member.controller;
 
 import com.ll.playon.domain.member.TestMemberHelper;
 import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.member.entity.enums.Gender;
+import com.ll.playon.domain.member.entity.enums.PlayStyle;
+import com.ll.playon.domain.member.entity.enums.SkillLevel;
 import com.ll.playon.domain.member.service.MemberService;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
@@ -13,12 +16,17 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -220,7 +228,7 @@ public class MemberControllerTest {
     @DisplayName("사용자 상세 조회")
     void getMyProfile() throws Exception {
         String authMember = "sampleUser1";
-        MockHttpServletRequestBuilder request = get("/api/auth/me");
+        MockHttpServletRequestBuilder request = get("/api/members/me");
         ResultActions resultActions = testMemberHelper.requestWithUserAuth(authMember, request);
 
         Member actor = memberService.findByUsername(authMember).get();

--- a/src/test/java/com/ll/playon/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/ll/playon/domain/member/controller/MemberControllerTest.java
@@ -240,4 +240,20 @@ public class MemberControllerTest {
                 .andExpect(jsonPath("$.data.memberDetail.username").value(actor.getUsername()))
                 .andExpect(jsonPath("$.data.ownedGames", hasSize(actor.getGames().size())));
     }
+
+    @Test
+    @DisplayName("닉네임으로 사용자 조회")
+    void getMembersWithNickname() throws Exception {
+        String nickname = "sampleUser";
+        ResultActions resultActions = mvc.perform(
+                get("/api/members/nickname?nickname=" + nickname)
+        );
+
+        int memberWithSameNicknameCount = memberService.findByNickname(nickname).size();
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(memberWithSameNicknameCount)));
+    }
 }

--- a/src/test/java/com/ll/playon/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/ll/playon/domain/member/controller/MemberControllerTest.java
@@ -2,9 +2,6 @@ package com.ll.playon.domain.member.controller;
 
 import com.ll.playon.domain.member.TestMemberHelper;
 import com.ll.playon.domain.member.entity.Member;
-import com.ll.playon.domain.member.entity.enums.Gender;
-import com.ll.playon.domain.member.entity.enums.PlayStyle;
-import com.ll.playon.domain.member.entity.enums.SkillLevel;
 import com.ll.playon.domain.member.service.MemberService;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
@@ -16,16 +13,12 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -221,5 +214,22 @@ public class MemberControllerTest {
         Optional<Member> memberCheck = memberService.findByUsername(authMember);
 
         assertTrue(memberCheck.isEmpty());
+    }
+
+    @Test
+    @DisplayName("사용자 상세 조회")
+    void getMyProfile() throws Exception {
+        String authMember = "sampleUser1";
+        MockHttpServletRequestBuilder request = get("/api/auth/me");
+        ResultActions resultActions = testMemberHelper.requestWithUserAuth(authMember, request);
+
+        Member actor = memberService.findByUsername(authMember).get();
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memberDetail.steamId").value(actor.getSteamId()))
+                .andExpect(jsonPath("$.data.memberDetail.username").value(actor.getUsername()))
+                .andExpect(jsonPath("$.data.ownedGames", hasSize(actor.getGames().size())));
     }
 }


### PR DESCRIPTION
## 작업 내용

1. 사용자 상세 조회 : 마이페이지 관련 api. 사용자 정보와 소유한 게임 명단 응답

2. 닉네임으로 사용자 조회 : 같은 닉네임을 가진 사용자 명단 응답

<br>

## 작업 예정

1. OpenFeign 적용 및 사용자 도메인 가벼운 리펙토링 (정리)

2. 게임 도메인 작업