### PR TITLE
[FEAT] 파티 신청 및 AOP 처리

### DIFF
--- a/src/main/java/com/ll/playon/domain/party/party/context/PartyContext.java
+++ b/src/main/java/com/ll/playon/domain/party/party/context/PartyContext.java
@@ -1,0 +1,21 @@
+package com.ll.playon.domain.party.party.context;
+
+import com.ll.playon.domain.party.party.entity.Party;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PartyContext {
+    private static final ThreadLocal<Party> currentParty = new ThreadLocal<>();
+
+    public static Party getParty() {
+        return currentParty.get();
+    }
+
+    public static void setParty(Party party) {
+        currentParty.set(party);
+    }
+
+    public static void clear() {
+        currentParty.remove();
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
+++ b/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
@@ -3,6 +3,7 @@ package com.ll.playon.domain.party.party.controller;
 import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.party.party.dto.request.PostPartyRequest;
 import com.ll.playon.domain.party.party.dto.request.PutPartyRequest;
+import com.ll.playon.domain.party.party.dto.response.GetAllPendingMemberResponse;
 import com.ll.playon.domain.party.party.dto.response.GetPartyDetailResponse;
 import com.ll.playon.domain.party.party.dto.response.PostPartyResponse;
 import com.ll.playon.domain.party.party.dto.response.PutPartyResponse;
@@ -67,5 +68,44 @@ public class PartyController {
         Member actor = this.userContext.findById(5L);
 
         this.partyService.deleteParty(actor, partyId);
+    }
+
+    @PostMapping("/{partyId}/members")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void requestParticipation(@PathVariable long partyId) {
+        // TODO : 추후 롤백
+//        Member actor = this.userContext.getActor();
+        Member actor = this.userContext.findById(7L);
+
+        this.partyService.requestParticipation(actor, partyId);
+    }
+
+    @PutMapping("/{partyId}/members/{memberId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void approveParticipation(@PathVariable long partyId, @PathVariable long memberId) {
+        // TODO : 추후 롤백
+//        Member actor = this.userContext.getActor();
+        Member actor = this.userContext.findById(5L);
+
+        this.partyService.approveParticipation(actor, partyId, memberId);
+    }
+
+    @DeleteMapping("/{partyId}/members/{memberId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void rejectParticipation(@PathVariable long partyId, @PathVariable long memberId) {
+        // TODO : 추후 롤백
+//        Member actor = this.userContext.getActor();
+        Member actor = this.userContext.findById(5L);
+
+        this.partyService.rejectParticipation(actor, partyId, memberId);
+    }
+
+    @GetMapping("/{partyId}/pending")
+    public RsData<GetAllPendingMemberResponse> getPartyPendingMembers(@PathVariable long partyId) {
+        // TODO : 추후 롤백
+//        Member actor = this.userContext.getActor();
+        Member actor = this.userContext.findById(5L);
+
+        return RsData.success(HttpStatus.OK, this.partyService.getPartyPendingMembers(actor, partyId));
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/dto/PartyDetailMemberDto.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/PartyDetailMemberDto.java
@@ -4,7 +4,7 @@ import com.ll.playon.domain.party.party.entity.PartyMember;
 import lombok.NonNull;
 
 public record PartyDetailMemberDto(
-        long partyMemberId,
+        long memberId,
 
         // TODO: 스팀 아바타로 변경할지 고려
         @NonNull
@@ -12,7 +12,7 @@ public record PartyDetailMemberDto(
 ) {
     public PartyDetailMemberDto(PartyMember partyMember) {
         this(
-                partyMember.getId(),
+                partyMember.getMember().getId(),
                 partyMember.getMember().getProfileImg()
         );
     }

--- a/src/main/java/com/ll/playon/domain/party/party/dto/response/GetAllPendingMemberResponse.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/response/GetAllPendingMemberResponse.java
@@ -1,0 +1,11 @@
+package com.ll.playon.domain.party.party.dto.response;
+
+import com.ll.playon.domain.party.party.dto.PartyDetailMemberDto;
+import java.util.List;
+import lombok.NonNull;
+
+public record GetAllPendingMemberResponse(
+        @NonNull
+        List<PartyDetailMemberDto> partyMembers
+) {
+}

--- a/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
@@ -74,4 +74,9 @@ public class Party extends BaseTime {
         this.maximum = maximum;
         this.partyStatus = PartyStatus.PENDING;
     }
+
+    public void addPartyMember(PartyMember partyMember) {
+        this.partyMembers.add(partyMember);
+        partyMember.setParty(this);
+    }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/entity/PartyMember.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/PartyMember.java
@@ -38,4 +38,11 @@ public class PartyMember extends BaseTime {
         this.member = member;
         this.partyRole = partyRole;
     }
+
+    public void delete() {
+        if (this.party != null) {
+            this.party.getPartyMembers().remove(this);
+            this.party = null;
+        }
+    }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyMemberRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyMemberRepository.java
@@ -3,9 +3,13 @@ package com.ll.playon.domain.party.party.repository;
 import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.party.party.entity.Party;
 import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.domain.party.party.type.PartyRole;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> {
     Optional<PartyMember> findByMemberAndParty(Member actor, Party party);
+
+    List<PartyMember> findAllByPartyAndPartyRole(Party party, PartyRole partyRole);
 }

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -1,10 +1,12 @@
 package com.ll.playon.domain.party.party.service;
 
 import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.party.party.context.PartyContext;
 import com.ll.playon.domain.party.party.dto.PartyDetailMemberDto;
 import com.ll.playon.domain.party.party.dto.PartyDetailTagDto;
 import com.ll.playon.domain.party.party.dto.request.PostPartyRequest;
 import com.ll.playon.domain.party.party.dto.request.PutPartyRequest;
+import com.ll.playon.domain.party.party.dto.response.GetAllPendingMemberResponse;
 import com.ll.playon.domain.party.party.dto.response.GetPartyDetailResponse;
 import com.ll.playon.domain.party.party.dto.response.PostPartyResponse;
 import com.ll.playon.domain.party.party.dto.response.PutPartyResponse;
@@ -14,12 +16,15 @@ import com.ll.playon.domain.party.party.entity.PartyTag;
 import com.ll.playon.domain.party.party.mapper.PartyMapper;
 import com.ll.playon.domain.party.party.mapper.PartyMemberMapper;
 import com.ll.playon.domain.party.party.mapper.PartyTagMapper;
-import com.ll.playon.domain.party.party.repository.PartyMemberRepository;
 import com.ll.playon.domain.party.party.repository.PartyRepository;
 import com.ll.playon.domain.party.party.type.PartyRole;
 import com.ll.playon.domain.party.party.type.PartyStatus;
+import com.ll.playon.domain.party.party.validation.PartyMemberValidation;
+import com.ll.playon.global.annotation.PartyOwnerOnly;
 import com.ll.playon.global.exceptions.ErrorCode;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +34,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class PartyService {
     private final PartyTagService partyTagService;
     private final PartyRepository partyRepository;
-    private final PartyMemberRepository partyMemberRepository;
 
     // 파티 생성
     @Transactional
@@ -71,14 +75,11 @@ public class PartyService {
     }
 
     // 파티 수정
+    // AOP에 필요한 파라미터
+    @PartyOwnerOnly
     @Transactional
     public PutPartyResponse updateParty(Member actor, long partyId, PutPartyRequest putPartyRequest) {
-        Party party = this.getParty(partyId);
-        PartyMember partyMember = this.getPartyMember(actor, party);
-
-        if (this.isNotPartyOwner(partyMember)) {
-            ErrorCode.INVALID_PARTY_MEMBER.throwServiceException();
-        }
+        Party party = PartyContext.getParty();
 
         // TODO: 유니크 제약 조건 있으면 체크
 
@@ -90,29 +91,81 @@ public class PartyService {
     }
 
     // 파티 삭제
+    // AOP에 필요한 파라미터
     // TODO: 추후 스케쥴링 처리
+    @PartyOwnerOnly
     @Transactional
     public void deleteParty(Member actor, long partyId) {
-        Party party = this.getParty(partyId);
-        PartyMember partyMember = this.getPartyMember(actor, party);
-
-        if (this.isNotPartyOwner(partyMember)) {
-            ErrorCode.INVALID_PARTY_MEMBER.throwServiceException();
-        }
+        Party party = PartyContext.getParty();
 
         party.setPartyStatus(PartyStatus.COMPLETED);
+    }
+
+    // 파티 참가 신청 리스트 조회
+    // AOP에 필요한 파라미터
+    @PartyOwnerOnly
+    @Transactional(readOnly = true)
+    public GetAllPendingMemberResponse getPartyPendingMembers(Member actor, long partyId) {
+        Party party = PartyContext.getParty();
+
+        return new GetAllPendingMemberResponse(
+                party.getPartyMembers().stream()
+                        .filter(pm -> pm.getPartyRole().equals(PartyRole.PENDING))
+                        .map(PartyDetailMemberDto::new)
+                        .toList());
+    }
+
+    // 파티 참가 신청
+    @Transactional
+    public void requestParticipation(Member actor, long partyId) {
+        Party party = this.getParty(partyId);
+        Optional<PartyMember> opPartyMember = this.getPartyMember(actor, party);
+
+        // 이미 해당 파티의 파티원일 경우
+        if (opPartyMember.isPresent()) {
+            PartyMember partyMember = opPartyMember.get();
+
+            // 파티장일 경우
+            PartyMemberValidation.checkPartyOwner(partyMember);
+
+            // 이미 해당 파티에 신청한 경우
+            PartyMemberValidation.checkPendingMember(partyMember);
+
+            // 파티원일 경우
+            ErrorCode.IS_ALREADY_PARTY_MEMBER.throwServiceException();
+        }
+
+        party.addPartyMember(PartyMemberMapper.of(actor, PartyRole.PENDING));
+    }
+
+    // 파티 참가 신청 승인
+    // AOP에 필요한 파라미터
+    @PartyOwnerOnly
+    @Transactional
+    public void approveParticipation(Member actor, long partyId, long memberId) {
+        Party party = PartyContext.getParty();
+
+        PartyMember pendingMember = this.getPendingMember(memberId, party);
+
+        pendingMember.setPartyRole(PartyRole.MEMBER);
+    }
+
+    // 파티 참가 신청 거부
+    // AOP에 필요한 파라미터
+    @PartyOwnerOnly
+    @Transactional
+    public void rejectParticipation(Member actor, long partyId, long memberId) {
+        Party party = PartyContext.getParty();
+
+        PartyMember pendingMember = this.getPendingMember(memberId, party);
+
+        pendingMember.delete();
     }
 
     // 파티 ID로 파티 조회
     private Party getParty(long partyId) {
         return this.partyRepository.findById(partyId)
                 .orElseThrow(ErrorCode.PARTY_NOT_FOUND::throwServiceException);
-    }
-
-    // Member, PartyId로 파티 멤버 조회
-    private PartyMember getPartyMember(Member actor, Party party) {
-        return this.partyMemberRepository.findByMemberAndParty(actor, party)
-                .orElseThrow(ErrorCode.PARTY_MEMBER_NOT_FOUND::throwServiceException);
     }
 
     // Party에서 파티장 조회
@@ -123,6 +176,15 @@ public class PartyService {
                 .orElseThrow(ErrorCode.PARTY_OWNER_NOT_FOUND::throwServiceException);
     }
 
+    // Party 참가 신청자인지 조회
+    private PartyMember getPendingMember(long memberId, Party party) {
+        return party.getPartyMembers().stream()
+                .filter(pm -> pm.getMember().getId() == memberId)
+                .filter(pm -> pm.getPartyRole().equals(PartyRole.PENDING))
+                .findFirst()
+                .orElseThrow(ErrorCode.PENDING_PARTY_MEMBER_NOT_FOUND::throwServiceException);
+    }
+
     // 요청으로부터 파티 태그 리스트 생성
     private List<PartyTag> createPartyTag(PostPartyRequest request, Party party) {
         return request.tags().stream()
@@ -130,9 +192,11 @@ public class PartyService {
                 .toList();
     }
 
-    // 파티 생성자 확인
-    private boolean isNotPartyOwner(PartyMember partyMember) {
-        return !partyMember.getPartyRole().equals(PartyRole.OWNER);
+    //     사용자, 파티 정보로 파티 멤버 조회
+    private Optional<PartyMember> getPartyMember(Member actor, Party party) {
+        return party.getPartyMembers().stream()
+                .filter(pm -> Objects.equals(pm.getMember().getId(), actor.getId()))
+                .findFirst();
     }
 
     // 파티 정보 수정

--- a/src/main/java/com/ll/playon/domain/party/party/validation/PartyMemberValidation.java
+++ b/src/main/java/com/ll/playon/domain/party/party/validation/PartyMemberValidation.java
@@ -1,0 +1,22 @@
+package com.ll.playon.domain.party.party.validation;
+
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.domain.party.party.type.PartyRole;
+import com.ll.playon.global.exceptions.ErrorCode;
+
+public class PartyMemberValidation {
+
+    // 파티장인지 확인
+    public static void checkPartyOwner(PartyMember partyMember) {
+        if (partyMember.getPartyRole().equals(PartyRole.OWNER)) {
+            ErrorCode.PARTY_OWNER_CANNOT_APPLY.throwServiceException();
+        }
+    }
+
+    // 이미 파티에 신청했는지 확인
+    public static void checkPendingMember(PartyMember partyMember) {
+        if (partyMember.getPartyRole().equals(PartyRole.PENDING)) {
+            ErrorCode.IS_ALREADY_REQUEST_PARTY.throwServiceException();
+        }
+    }
+}

--- a/src/main/java/com/ll/playon/global/annotation/PartyOwnerOnly.java
+++ b/src/main/java/com/ll/playon/global/annotation/PartyOwnerOnly.java
@@ -1,0 +1,11 @@
+package com.ll.playon.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PartyOwnerOnly {
+}

--- a/src/main/java/com/ll/playon/global/aspect/PartyOwnerCheckAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/PartyOwnerCheckAspect.java
@@ -1,0 +1,50 @@
+package com.ll.playon.global.aspect;
+
+import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.party.party.context.PartyContext;
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.party.repository.PartyRepository;
+import com.ll.playon.domain.party.party.type.PartyRole;
+import com.ll.playon.global.exceptions.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PartyOwnerCheckAspect {
+    private final PartyRepository partyRepository;
+
+    @Around("@annotation(com.ll.playon.global.annotation.PartyOwnerOnly)")
+    public Object checkPartyOwner(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object[] args = joinPoint.getArgs();
+
+        Member actor = (Member) args[0];
+        Long partyId = (Long) args[1];
+        Party party = this.partyRepository.findById(partyId)
+                .orElseThrow(ErrorCode.PARTY_NOT_FOUND::throwServiceException);
+
+        if (!isNotPartyOwner(actor, party)) {
+            throw ErrorCode.IS_NOT_PARTY_OWNER.throwServiceException();
+        }
+
+        PartyContext.setParty(party);
+
+        try {
+            return joinPoint.proceed(args);
+        } finally {
+            PartyContext.clear();
+        }
+    }
+
+    private boolean isNotPartyOwner(Member actor, Party party) {
+        return party.getPartyMembers().stream()
+                .anyMatch(pm -> pm.getPartyRole().equals(PartyRole.OWNER)
+                                && pm.getMember().getId().equals(actor.getId()));
+    }
+}

--- a/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
@@ -61,12 +61,16 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 멤버를 찾을 수 없습니다."),
 
     // Party
+    IS_ALREADY_REQUEST_PARTY(HttpStatus.FORBIDDEN, "파티 신청이 진행 중입니다."),
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "파티가 존재하지 않습니다."),
 
     // PartyMember
+    IS_NOT_PARTY_OWNER(HttpStatus.FORBIDDEN, "해당 파티의 파티장이 아닙니다."),
+    IS_ALREADY_PARTY_MEMBER(HttpStatus.FORBIDDEN, "이미 해당 파티의 파티원입니다."),
+    PARTY_OWNER_CANNOT_APPLY(HttpStatus.FORBIDDEN, "파티장은 파티에 신청할 수 없습니다."),
     PARTY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "파티 멤버가 존재하지 않습니다."),
     PARTY_OWNER_NOT_FOUND(HttpStatus.NOT_FOUND, "파티장이 존재하지 않습니다."),
-    INVALID_PARTY_MEMBER(HttpStatus.FORBIDDEN, "해당 파티의 파티장이 아닙니다."),
+    PENDING_PARTY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "파티 참가를 신청한 사용자가 아닙니다."),
 
     // Tag
     TAG_TYPE_CONVERT_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "태그 타입 변환에 실패하였습니다."),

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -87,6 +87,42 @@ public class BaseInitData {
         memberRepository.save(owner);
 
         memberService.saveUserGameList(gameAppIds, owner);
+
+        Member user1 = Member.builder()
+                .steamId(1515L)
+                .username("user1")
+                .nickname("user1")
+                .profileImg("")
+                .lastLoginAt(LocalDateTime.now())
+                .role(Role.USER)
+                .build();
+        memberRepository.save(user1);
+
+        memberService.saveUserGameList(gameAppIds, user1);
+
+        Member user2 = Member.builder()
+                .steamId(2222L)
+                .username("user2")
+                .nickname("user2")
+                .profileImg("")
+                .lastLoginAt(LocalDateTime.now())
+                .role(Role.USER)
+                .build();
+        memberRepository.save(user2);
+
+        memberService.saveUserGameList(gameAppIds, user2);
+
+        Member user3 = Member.builder()
+                .steamId(3333L)
+                .username("user3")
+                .nickname("user3")
+                .profileImg("")
+                .lastLoginAt(LocalDateTime.now())
+                .role(Role.USER)
+                .build();
+        memberRepository.save(user3);
+
+        memberService.saveUserGameList(gameAppIds, user3);
     }
 
     @Transactional


### PR DESCRIPTION
closes #27 

## 1. 파티 참가 신청 구현
- 이미 파티장, 신청자, 파티원일 경우 각각 다르게 예외 처리

## 2. 파티 참가 승인 구현
- 파티장만 참가 승인 가능

## 3. 파티 참가 거절 구현
- 파티장만 참가 거절 가능

## 4. 파티 참가 신청 리스트 조회
- 파티장만 참가 리스트 조회 가능

## 5. 어노테이션 추가 및 AOP 도입
- 파티장 인가 체크 어노테이션 및 AOP 처리로 변경
- ThreadLocal 도입하여 각 요청 시의 Party 정보를 저장

 ### AOP 및 ThreadLocal 도입 이유
---
- 파티장 인가 체크가 중복으로 많이 재사용됨
- 서비스 내의 코드를 최대한으로 줄이고 싶었음
- 해당 어노테이션이 쓰이는 파티 수정, 파티 참가 관련 작업들은 비동기 실행이 필요 없음
  - `PartyContext` 컴포넌트 생성 후, `ThreadLocal<Party>` 생성하여 각 요청 시의 `Party` 정보 저장
  - `AOP` 를 통해 해당 **partyId**의 `Party` 정보를 `Context` 에 저장
  - 서비스 메서드 종료 후 `clear` 하여 호출 시마다 초기화하도록 설정
  - 이후 비동기 작업 필요 시 `RequestScope` 빈을 등록하는 `Context` 추가 후 해당 메서드에 어노테이션으로 사용 예정

### 이러한 방법은 성능에 영향을 끼칠까?
---
- 결론부터 말하자면 매우매우 미비
- 애초에 `AOP` 란 메서드 실행 **전/후/전후** 에 메서드를 한 번 더 호출하는 것에 불과
- `PartyContext` 에 저장 및 호출하는 것 또한 결국 `O(1)` 의 시간복잡도를 가짐