### PR TITLE
[FEAT] 파티 리스트 조회 및 검색 기능 구현

### DIFF
--- a/src/main/java/com/ll/playon/domain/party/party/dto/request/GetAllPartiesRequest.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/request/GetAllPartiesRequest.java
@@ -1,0 +1,27 @@
+package com.ll.playon.domain.party.party.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public record GetAllPartiesRequest(
+
+//        // TODO: 수정할 가능성
+//        @NotNull
+//        String gameName,
+
+        // TODO: 추후 게임 작업 완료되면 진행
+//        @NotNull
+//        List<String> genres,
+
+        @NotNull
+        List<@Valid PartyTagRequest> tags
+) {
+    public GetAllPartiesRequest {
+//        gameName = Objects.requireNonNullElse(gameName, "");
+//        genres = Objects.requireNonNullElse(genres, new ArrayList<>());
+        tags = Objects.requireNonNullElse(tags, new ArrayList<>());
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/party/dto/response/GetPartyResponse.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/response/GetPartyResponse.java
@@ -1,0 +1,55 @@
+package com.ll.playon.domain.party.party.dto.response;
+
+import com.ll.playon.domain.party.party.dto.PartyDetailMemberDto;
+import com.ll.playon.domain.party.party.dto.PartyDetailTagDto;
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.domain.party.party.entity.PartyTag;
+import com.ll.playon.domain.party.party.type.PartyRole;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.NonNull;
+
+public record GetPartyResponse(
+        long partyId,
+
+        @NotBlank
+        String name,
+
+        @NonNull
+        String description,
+
+        @NonNull
+        LocalDateTime partyAt,
+
+        int total,
+
+        @NonNull
+        List<PartyDetailMemberDto> members,
+
+        @NonNull
+        List<PartyDetailTagDto> partyTags
+
+        // TODO: 1. 스팀 게임 헤더 이미지
+        //       2. 스팀 아바타로 변경할지 고려
+) {
+    public GetPartyResponse(Party party, List<PartyTag> tagDtos, List<PartyMember> memberDtos) {
+        this(
+                party.getId(),
+                party.getName(),
+                party.getDescription(),
+                party.getPartyAt(),
+                (int) memberDtos.stream()
+                        .filter(pm -> !pm.getPartyRole().equals(PartyRole.PENDING))
+                        .count(),
+                memberDtos.stream()
+                        .map(PartyDetailMemberDto::new)
+                        .toList(),
+                tagDtos.stream()
+                        .map(tag -> tag.getValue().getKoreanValue())
+                        .map(PartyDetailTagDto::new)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
@@ -7,7 +7,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +20,12 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
+@Table(
+        name = "party",
+        indexes = {
+                @Index(name = "idx_party_status_partyAt", columnList = "partyStatus, partyAt")
+        }
+)
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/ll/playon/domain/party/party/entity/PartyMember.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/PartyMember.java
@@ -8,8 +8,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,11 +18,17 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
+@Table(
+        name = "party_members",
+        indexes = {
+                @Index(name = "idx_party_member_party_id_role", columnList = "party_id, partyRole")
+        }
+)
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PartyMember extends BaseTime {
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/ll/playon/domain/party/party/entity/PartyTag.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/PartyTag.java
@@ -21,10 +21,9 @@ import lombok.Setter;
 
 @Entity
 @Table(
-        name = "partyTags",
+        name = "party_tags",
         indexes = {
-                @Index(name = "idx_party_tag_type_value", columnList = "tagType, tagValue"),
-                @Index(name = "idx_party_tag_party_id", columnList = "party_id")
+                @Index(name = "idx_party_tag_party_id_value", columnList = "party_id, tag_value"),
         }
 )
 @Getter
@@ -37,18 +36,22 @@ public class PartyTag extends BaseTime {
     private Party party;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "tagType")
+    @Column(name = "tag_type")
     private TagType type;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "tagValue")
+    @Column(name = "tag_value")
     private TagValue value;
 
     // TODO: 더 좋은 방법이 있나 고민해볼 것
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         PartyTag partyTag = (PartyTag) o;
 
         return this.type == partyTag.type && value == partyTag.value && party.equals(partyTag.party);

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -1,7 +1,107 @@
 package com.ll.playon.domain.party.party.repository;
 
 import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.domain.party.party.entity.PartyTag;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PartyRepository extends JpaRepository<Party, Long> {
+
+    // 1개 이상 태그만 충족하면 검색 가능, 우선 보류
+//    @Query("""
+//            SELECT p.id
+//            FROM Party p
+//            WHERE p.partyStatus = 'PENDING'
+//            AND (:partyAt IS NULL OR (p.partyAt >= :partyAt))
+//            AND EXISTS (
+//                SELECT 1
+//                FROM PartyTag pt
+//                WHERE pt.party = p
+//                AND pt.value IN :tagValues
+//            )
+//            """)
+//    Page<Long> findPartyIdsWithFilter(
+//            @Param("partyAt") LocalDateTime partyAt,
+//            @Param("tagValues") List<String> tagValues,
+//            Pageable pageable
+//    );
+
+    // 필터 조건 사용 쿼리
+    @Query("""
+            SELECT p.id
+            FROM Party p
+            JOIN PartyTag pt ON pt.party = p
+            WHERE p.partyStatus = 'PENDING'
+            AND (:partyAt IS NULL OR (p.partyAt >= :partyAt))
+            AND pt.value IN :tagValues
+            GROUP BY p.id
+            HAVING COUNT(pt.value) = :tagSize
+            """)
+    Page<Long> findPartyIdsWithFilter(
+            @Param("partyAt") LocalDateTime partyAt,
+            @Param("tagValues") List<String> tagValues,
+            @Param("tagSize") long tagSize,
+            Pageable pageable
+    );
+
+    // 추후 성능 비교
+//    @Query("""
+//            SELECT p.id
+//            FROM Party p
+//            WHERE p.partyStatus = 'PENDING'
+//            AND (:partyAt IS NULL OR (p.partyAt >= :partyAt))
+//            AND (
+//                SELECT COUNT(pt)
+//                FROM PartyTag pt
+//                WHERE pt.party = p
+//                AND pt.value IN :tagValues
+//            ) = :tagSize
+//            """)
+//    Page<Long> findPartyIdsWithFilter(
+//            @Param("partyAt") LocalDateTime partyAt,
+//            @Param("tagValues") List<String> tagValues,
+//            @Param("tagSize") long tagSize,
+//            Pageable pageable
+//    );
+
+    @Query("""
+            SELECT p.id
+            FROM Party p
+            WHERE p.partyStatus = 'PENDING'
+            AND (:partyAt IS NULL OR (p.partyAt >= :partyAt))
+            """)
+    Page<Long> findPartyIdsWithoutFilter(
+            @Param("partyAt") LocalDateTime partyAt,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT p
+            FROM Party p
+            WHERE p.id IN :partyIds
+            """)
+    List<Party> findPartiesByIds(@Param("partyIds") List<Long> partyIds);
+
+    @Query("""
+            SELECT pt
+            FROM PartyTag pt
+            JOIN FETCH pt.party p
+            WHERE p.id IN :partyIds
+            """)
+    List<PartyTag> findPartyTagsByPartyIds(@Param("partyIds") List<Long> partyIds);
+
+    @Query("""
+            SELECT pm
+            FROM PartyMember pm
+            JOIN FETCH pm.party p
+            WHERE p.id IN :partyIds
+            AND pm.partyRole <> 'PENDING'
+            """)
+    List<PartyMember> findPartyMembersByPartyIds(@Param("partyIds") List<Long> partyIds);
 }

--- a/src/main/java/com/ll/playon/domain/party/party/util/PartySortUtils.java
+++ b/src/main/java/com/ll/playon/domain/party/party/util/PartySortUtils.java
@@ -1,0 +1,16 @@
+package com.ll.playon.domain.party.party.util;
+
+import java.util.Map;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
+public class PartySortUtils {
+    private static final Map<String, Sort> SORT_MAP = Map.of(
+            "latest", Sort.by(Direction.DESC, "createdAt"),
+            "popular", Sort.by(Direction.DESC, "hit")
+    );
+
+    public static Sort getSort(String orderBy) {
+        return SORT_MAP.getOrDefault(orderBy, SORT_MAP.get("latest"));
+    }
+}


### PR DESCRIPTION
closes #32 

## 1. 파티 리스트 조회
- 참여 가능한 파티 리스트 조회

## 2. 파티 리스트 검색
- 검색 기능 1차 구현
  - 추가 필요한 정보들은 다른 도메인 엔티티 작업 후 진행
- 쿼리 최적화 진행
  - 다중 `JOIN` 사용 지양
  - 필터링 결과의 `ID` 값을 우선적으로 추출
  - 해당 `ID` 값을 사용하여 필요한 연관관계 정보들 따로 쿼리로 추출
  - 해당 정보들 한 번에 합쳐서 `DTO` 로 변환 후 응답

## 3. 인덱스 재정의
- 검색에 필요한 인덱스 재설정
  - 검색 성능 고려 및 인덱스 순서 고려