### PR TITLE
[FEAT] OpenFeign 도입 및 소유한 게임 리스트로 선호 장르 계산

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.2.1'
 
 	// OpenAPI (Swagger) 추가
 	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1"

--- a/src/main/java/com/ll/playon/PlayOnApplication.java
+++ b/src/main/java/com/ll/playon/PlayOnApplication.java
@@ -2,10 +2,12 @@ package com.ll.playon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableFeignClients
 public class PlayOnApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/ll/playon/domain/game/game/repository/GenreRepository.java
+++ b/src/main/java/com/ll/playon/domain/game/game/repository/GenreRepository.java
@@ -3,5 +3,8 @@ package com.ll.playon.domain.game.game.repository;
 import com.ll.playon.domain.game.game.entity.SteamGenre;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface GenreRepository extends JpaRepository<SteamGenre, Long> {
+    Optional<SteamGenre> findByName(String mostFrequentGenre);
 }

--- a/src/main/java/com/ll/playon/domain/member/dto/ProfileMemberDetailDto.java
+++ b/src/main/java/com/ll/playon/domain/member/dto/ProfileMemberDetailDto.java
@@ -1,8 +1,8 @@
 package com.ll.playon.domain.member.dto;
 
+import com.ll.playon.domain.game.game.entity.SteamGenre;
 import com.ll.playon.domain.member.entity.enums.Gender;
 import com.ll.playon.domain.member.entity.enums.PlayStyle;
-import com.ll.playon.domain.member.entity.enums.PreferredGenres;
 import com.ll.playon.domain.member.entity.enums.SkillLevel;
 
 import java.time.LocalDateTime;
@@ -16,5 +16,5 @@ public record ProfileMemberDetailDto(
         PlayStyle playStyle,
         SkillLevel skillLevel,
         Gender gender,
-        PreferredGenres preferredGenres
+        SteamGenre preferredGenre
 ){}

--- a/src/main/java/com/ll/playon/domain/member/entity/Member.java
+++ b/src/main/java/com/ll/playon/domain/member/entity/Member.java
@@ -1,8 +1,14 @@
 package com.ll.playon.domain.member.entity;
 
-import com.ll.playon.domain.member.entity.enums.*;
+import com.ll.playon.domain.game.game.entity.SteamGenre;
+import com.ll.playon.domain.member.entity.enums.Gender;
+import com.ll.playon.domain.member.entity.enums.PlayStyle;
+import com.ll.playon.domain.member.entity.enums.Role;
+import com.ll.playon.domain.member.entity.enums.SkillLevel;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -86,10 +92,8 @@ public class Member {
     @Builder.Default
     private Gender gender = Gender.MALE;
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    @Builder.Default
-    private PreferredGenres preferredGenres = PreferredGenres.RPG; // TODO : 게임 보유 목록 통해 설정
+    @JdbcTypeCode(SqlTypes.JSON)
+    private SteamGenre preferredGenre; // TODO : 선호 장르 여러개 넣고 싶은데 일단 1개만
 
     public Member(long id, String username, Role role) {
         super();

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -166,7 +166,10 @@ public class MemberService {
                 targetMember.setSteamId(steamId);
                 memberRepository.save(targetMember);
 
-                saveUserGameList(steamAPI.getUserGames(steamId), targetMember);
+                List<Long> userGames = steamAPI.getUserGames(steamId);
+                SteamGenre preferredGenre = steamAPI.getPreferredGenre(userGames);
+                memberRepository.save(targetMember.toBuilder().preferredGenre(preferredGenre).build());
+                saveUserGameList(userGames, targetMember);
                 return targetMember;
             })
             .orElseThrow(ErrorCode.AUTHORIZATION_FAILED::throwServiceException);

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.ll.playon.domain.member.service;
 
+import com.ll.playon.domain.game.game.entity.SteamGenre;
 import com.ll.playon.domain.member.dto.*;
 import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.member.entity.MemberSteamData;
@@ -120,6 +121,8 @@ public class MemberService {
         memberRepository.save(newMember);
 
         List<Long> userGames = steamAPI.getUserGames(steamId);
+        SteamGenre preferredGenre = steamAPI.getPreferredGenre(userGames);
+        memberRepository.save(newMember.toBuilder().preferredGenre(preferredGenre).build());
         saveUserGameList(userGames, newMember);
 
         return newMember;
@@ -207,7 +210,7 @@ public class MemberService {
         ProfileMemberDetailDto profileMemberDetailDto = new ProfileMemberDetailDto(
                 member.getSteamId(), member.getUsername(), member.getNickname(), member.getProfileImg(),
                 member.getLastLoginAt(), member.getPlayStyle(), member.getSkillLevel(),
-                member.getGender(), member.getPreferredGenres()
+                member.getGender(), member.getPreferredGenre()
         );
 
         // 보유한 게임 목록 조회

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -119,7 +119,8 @@ public class MemberService {
                 .build();
         memberRepository.save(newMember);
 
-        saveUserGameList(steamAPI.getUserGames(steamId), newMember);
+        List<Long> userGames = steamAPI.getUserGames(steamId);
+        saveUserGameList(userGames, newMember);
 
         return newMember;
     }

--- a/src/main/java/com/ll/playon/global/app/AppConfig.java
+++ b/src/main/java/com/ll/playon/global/app/AppConfig.java
@@ -5,9 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.client.RestTemplate;
 
 @Configuration
 @ConfigurationProperties(prefix= "app")
@@ -23,11 +21,6 @@ public class AppConfig {
     @Autowired
     public void setObjectMapper(ObjectMapper objectMapper) {
         AppConfig.objectMapper = objectMapper;
-    }
-
-    @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
     }
 
     // 프론트엔드 URL 반환

--- a/src/main/java/com/ll/playon/global/openFeign/SteamApiClient.java
+++ b/src/main/java/com/ll/playon/global/openFeign/SteamApiClient.java
@@ -1,0 +1,26 @@
+package com.ll.playon.global.openFeign;
+
+import com.ll.playon.global.openFeign.dto.SteamGameResponse;
+import com.ll.playon.global.openFeign.dto.SteamResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+// Steam API 기본 URL 설정
+@FeignClient(name = "steamApiClient", url = "https://api.steampowered.com")
+public interface SteamApiClient {
+
+    // GET 요청을 해당 엔드포인트로 보냄
+    @GetMapping("/ISteamUser/GetPlayerSummaries/v2/")
+    SteamResponse getPlayerSummaries(
+            // API 키와 steamId 를 쿼리 파라미터로 전달
+            @RequestParam("key") String apiKey,
+            @RequestParam("steamids") String steamIds
+    );
+
+    @GetMapping("IPlayerService/GetOwnedGames/v1/")
+    SteamGameResponse getPlayerOwnedGames(
+            @RequestParam("key") String apiKey,
+            @RequestParam("steamid") String steamId
+    );
+}

--- a/src/main/java/com/ll/playon/global/openFeign/SteamOpenIdClient.java
+++ b/src/main/java/com/ll/playon/global/openFeign/SteamOpenIdClient.java
@@ -1,0 +1,13 @@
+package com.ll.playon.global.openFeign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "steamOpenIdClient", url = "https://steamcommunity.com")
+public interface SteamOpenIdClient {
+
+    @PostMapping(value = "/openid/login", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    String validateSteamId(@RequestBody String requestBody);
+}

--- a/src/main/java/com/ll/playon/global/openFeign/SteamStoreClient.java
+++ b/src/main/java/com/ll/playon/global/openFeign/SteamStoreClient.java
@@ -1,0 +1,17 @@
+package com.ll.playon.global.openFeign;
+
+import com.ll.playon.global.openFeign.dto.SteamGameDetailResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "steamStoreClient", url = "https://store.steampowered.com")
+public interface SteamStoreClient {
+
+    @GetMapping("/api/appdetails")
+    SteamGameDetailResponse getGameDetail(
+            @RequestParam("appids") Integer appId,
+            @RequestParam("cc") String countryCode,
+            @RequestParam("filters") String filters
+    );
+}

--- a/src/main/java/com/ll/playon/global/openFeign/dto/Game.java
+++ b/src/main/java/com/ll/playon/global/openFeign/dto/Game.java
@@ -1,0 +1,15 @@
+package com.ll.playon.global.openFeign.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Game {
+    @JsonProperty("appid")
+    private String appId;
+
+    @JsonProperty("playtime_forever")
+    private int playtime;
+}

--- a/src/main/java/com/ll/playon/global/openFeign/dto/GameDetail.java
+++ b/src/main/java/com/ll/playon/global/openFeign/dto/GameDetail.java
@@ -1,0 +1,14 @@
+package com.ll.playon.global.openFeign.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Setter
+@Getter
+public class GameDetail {
+    @JsonProperty("genres")
+    private List<Genre> genres;
+}

--- a/src/main/java/com/ll/playon/global/openFeign/dto/GameDetailDeserializer.java
+++ b/src/main/java/com/ll/playon/global/openFeign/dto/GameDetailDeserializer.java
@@ -1,0 +1,23 @@
+package com.ll.playon.global.openFeign.dto;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+
+public class GameDetailDeserializer extends JsonDeserializer<GameDetail> {
+    @Override
+    public GameDetail deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonNode node = p.getCodec().readTree(p);
+
+        // data 필드가 배열([])이면 null 반환
+        if (node.isArray()) {
+            return null;
+        }
+
+        // 정상적인 객체이면 Jackson이 자동 매핑
+        return p.getCodec().treeToValue(node, GameDetail.class);
+    }
+}

--- a/src/main/java/com/ll/playon/global/openFeign/dto/GameDetailWrapper.java
+++ b/src/main/java/com/ll/playon/global/openFeign/dto/GameDetailWrapper.java
@@ -1,0 +1,16 @@
+package com.ll.playon.global.openFeign.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class GameDetailWrapper {
+    private boolean success;
+
+    @JsonProperty("data")
+    @JsonDeserialize(using = GameDetailDeserializer.class) // 커스텀 deserializer 적용
+    private GameDetail gameData;
+}

--- a/src/main/java/com/ll/playon/global/openFeign/dto/GameResponse.java
+++ b/src/main/java/com/ll/playon/global/openFeign/dto/GameResponse.java
@@ -1,0 +1,17 @@
+package com.ll.playon.global.openFeign.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class GameResponse {
+    @JsonProperty("games")
+    private List<Game> games;
+
+    @JsonProperty("game_count")
+    private int gameCount;
+}

--- a/src/main/java/com/ll/playon/global/openFeign/dto/Genre.java
+++ b/src/main/java/com/ll/playon/global/openFeign/dto/Genre.java
@@ -1,0 +1,11 @@
+package com.ll.playon.global.openFeign.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class Genre {
+    private String id;
+    private String description;
+}

--- a/src/main/java/com/ll/playon/global/openFeign/dto/Player.java
+++ b/src/main/java/com/ll/playon/global/openFeign/dto/Player.java
@@ -1,0 +1,15 @@
+package com.ll.playon.global.openFeign.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Player {
+    @JsonProperty("personaname")
+    private String nickname;
+
+    @JsonProperty("avatarmedium") // medium 사이즈 프로필 사용
+    private String avatar;
+}

--- a/src/main/java/com/ll/playon/global/openFeign/dto/PlayerResponse.java
+++ b/src/main/java/com/ll/playon/global/openFeign/dto/PlayerResponse.java
@@ -1,0 +1,14 @@
+package com.ll.playon.global.openFeign.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class PlayerResponse {
+    @JsonProperty("players")
+    private List<Player> players;
+}

--- a/src/main/java/com/ll/playon/global/openFeign/dto/SteamGameDetailResponse.java
+++ b/src/main/java/com/ll/playon/global/openFeign/dto/SteamGameDetailResponse.java
@@ -1,0 +1,19 @@
+package com.ll.playon.global.openFeign.dto;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Setter
+@Getter
+public class SteamGameDetailResponse {
+    private Map<String, GameDetailWrapper> games = new HashMap<>();
+
+    @JsonAnySetter
+    public void addGame(String key, GameDetailWrapper value) {
+        games.put(key, value);
+    }
+}

--- a/src/main/java/com/ll/playon/global/openFeign/dto/SteamGameResponse.java
+++ b/src/main/java/com/ll/playon/global/openFeign/dto/SteamGameResponse.java
@@ -1,0 +1,12 @@
+package com.ll.playon.global.openFeign.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SteamGameResponse {
+    @JsonProperty("response")
+    private GameResponse response;
+}

--- a/src/main/java/com/ll/playon/global/openFeign/dto/SteamResponse.java
+++ b/src/main/java/com/ll/playon/global/openFeign/dto/SteamResponse.java
@@ -1,0 +1,13 @@
+package com.ll.playon.global.openFeign.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SteamResponse {
+    @JsonProperty("response")
+    private PlayerResponse response;
+}
+

--- a/src/main/java/com/ll/playon/global/steamAPI/SteamAPI.java
+++ b/src/main/java/com/ll/playon/global/steamAPI/SteamAPI.java
@@ -1,9 +1,10 @@
 package com.ll.playon.global.steamAPI;
 
+import com.ll.playon.domain.game.game.entity.SteamGenre;
+import com.ll.playon.domain.game.game.repository.GenreRepository;
 import com.ll.playon.global.openFeign.SteamApiClient;
-import com.ll.playon.global.openFeign.dto.Player;
-import com.ll.playon.global.openFeign.dto.SteamGameResponse;
-import com.ll.playon.global.openFeign.dto.SteamResponse;
+import com.ll.playon.global.openFeign.SteamStoreClient;
+import com.ll.playon.global.openFeign.dto.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,12 +13,17 @@ import org.springframework.stereotype.Service;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class SteamAPI {
     private final SteamApiClient steamApiClient;
+    private final SteamStoreClient steamStoreClient;
+    private final GenreRepository genreRepository;
+
+    private static final int MAX_GAMES_TO_ANALYZE = 30;
 
     // TODO : 스팀 API 장애 대응
 
@@ -40,5 +46,37 @@ public class SteamAPI {
         return steamGameResponse.getResponse().getGames().stream()
                 .map(game -> Long.valueOf(game.getAppId()))
                 .toList();
+    }
+
+    public SteamGenre getPreferredGenre(List<Long> userGames) {
+        Map<String, Integer> genreCountMap = new HashMap<>();
+
+        int count = 0;
+
+        for(Long gameId : userGames) {
+            String appId = String.valueOf(gameId);
+            if(count++ > MAX_GAMES_TO_ANALYZE) break;
+
+            // TODO : DB 조회로
+            SteamGameDetailResponse response = steamStoreClient.getGameDetail(
+                    Integer.valueOf(appId), "KR", "genres");
+
+            GameDetailWrapper gameDetailWrapper = response.getGames().get(appId);
+            if (gameDetailWrapper == null || !gameDetailWrapper.isSuccess()) continue;
+            if (response.getGames().get(appId).getGameData() == null) continue;
+
+            List<Genre> genres = response.getGames().get(appId).getGameData().getGenres();
+            for (Genre genre : genres) {
+                genreCountMap.put(genre.getDescription(), genreCountMap.getOrDefault(genre.getDescription(), 0) + 1);
+            }
+        }
+
+        String preferredGenre = genreCountMap.entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(null);
+
+        Optional<SteamGenre> genre = genreRepository.findByName(preferredGenre);
+        return genre.orElseGet(() -> genreRepository.save(SteamGenre.builder().name(preferredGenre).build()));
     }
 }

--- a/src/test/java/com/ll/playon/domain/member/controller/SteamAuthTest.java
+++ b/src/test/java/com/ll/playon/domain/member/controller/SteamAuthTest.java
@@ -2,31 +2,32 @@ package com.ll.playon.domain.member.controller;
 
 import com.ll.playon.domain.member.TestMemberHelper;
 import com.ll.playon.domain.member.repository.MemberSteamDataRepository;
+import com.ll.playon.global.openFeign.SteamApiClient;
+import com.ll.playon.global.openFeign.SteamOpenIdClient;
+import com.ll.playon.global.openFeign.dto.*;
 import jakarta.servlet.http.Cookie;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.web.client.RestTemplate;
 
 import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -37,12 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class SteamAuthTest {
 
     @Autowired
-    private MockMvc mvc; // 컨트롤러 호출을 위한 MockMvc
-
-    @Autowired
-    private RestTemplate restTemplate;
-
-    private MockRestServiceServer mockServer;
+    private MockMvc mvc;
 
     @Autowired
     private TestMemberHelper testMemberHelper;
@@ -50,20 +46,21 @@ public class SteamAuthTest {
     @Autowired
     private MemberSteamDataRepository memberSteamDataRepository;
 
+    @MockitoBean
+    private SteamOpenIdClient mockSteamOpenIdClient;
+
+    @MockitoBean
+    private SteamApiClient mockSteamApiClient;
+
     @Value("${custom.steam.apikey}")
     private String apikey;
-
-    @BeforeEach
-    void setUp() {
-        mockServer = MockRestServiceServer.createServer(restTemplate);
-    }
 
     @Test
     @DisplayName("스팀 로그인 성공 테스트, 스팀 id 123, sampleUser1")
     void test1() throws Exception {
         // 가짜 API 응답 설정
-        mockServer.expect(requestTo("https://steamcommunity.com/openid/login"))
-                .andRespond(withSuccess("is_valid:true", MediaType.TEXT_PLAIN));
+        Mockito.when(mockSteamOpenIdClient.validateSteamId(Mockito.any()))
+                .thenReturn("is_valid:true");
 
         // 컨트롤러 호출
         ResultActions resultActions = mvc.perform(
@@ -94,37 +91,49 @@ public class SteamAuthTest {
         );
 
         // mock 서버 검증 (API가 제대로 호출되었는지 확인)
-        mockServer.verify();
+        Mockito.verify(mockSteamOpenIdClient).validateSteamId(Mockito.any());
     }
 
     @Test
     @DisplayName("스팀 회원가입 성공 테스트, 스팀 id 1234, 새로운 사용자")
     void signupNewUser() throws Exception {
         // 가짜 API 응답 설정
-        mockServer.expect(requestTo("https://steamcommunity.com/openid/login"))
-                .andRespond(withSuccess("is_valid:true", MediaType.TEXT_PLAIN));
+        Mockito.when(mockSteamOpenIdClient.validateSteamId(Mockito.any()))
+                .thenReturn("is_valid:true");
 
         // 가짜 사용자 프로필 응답 설정
-        String fakeUserProfileResponse = """
-        {
-          "response": {
-            "players": [
-              {
-                "personaname": "everydayplayday",
-                "avatarfull": "https://avatars.steamstatic.com/66acac8c7e55dd6a4c70dc5eb1d783c015a1d284_full.jpg"
-              }
-            ]
-          }
-        }
-        """;
-        mockServer.expect(requestTo(String.format("https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v2/?key=%s&steamids=1234", apikey)))
-                .andRespond(withSuccess(fakeUserProfileResponse, MediaType.APPLICATION_JSON));
+        SteamResponse fakeSteamResponse = new SteamResponse();
+        PlayerResponse playerResponse = new PlayerResponse();
+        Player player = new Player();
+
+        player.setNickname("everydayplayday");
+        player.setAvatar("https://avatars.steamstatic.com/66acac8c7e55dd6a4c70dc5eb1d783c015a1d284_medium.jpg");
+
+        playerResponse.setPlayers(List.of(player));
+        fakeSteamResponse.setResponse(playerResponse);
+
+        Mockito.when(mockSteamApiClient.getPlayerSummaries(eq(apikey),Mockito.any()))
+                .thenReturn(fakeSteamResponse);
 
         // 가짜 게임 리스트 응답 설정
-        String fakeGameListResponse = "{ \"response\": { \"games\": [ { \"appid\": 123 }, { \"appid\": 456 } ] } }";
-        mockServer.expect(requestTo(String.format("https://api.steampowered.com/IPlayerService/GetOwnedGames/v1/?key=%s&steamid=1234",apikey)))
-                .andRespond(withSuccess(fakeGameListResponse, MediaType.APPLICATION_JSON));
+        SteamGameResponse fakeSteamGameResponse = new SteamGameResponse();
+        GameResponse gameResponse = new GameResponse();
+        Game game1 = new Game();
+        Game game2 = new Game();
+        Game game3 = new Game();
 
+        game1.setAppId("2246340");
+        game1.setPlaytime(111);
+        game2.setAppId("2680010");
+        game2.setPlaytime(222);
+        game3.setAppId("2456740");
+        game3.setPlaytime(333);
+
+        gameResponse.setGames(List.of(game1, game2, game3));
+        fakeSteamGameResponse.setResponse(gameResponse);
+
+        Mockito.when(mockSteamApiClient.getPlayerOwnedGames(eq(apikey),Mockito.any()))
+                .thenReturn(fakeSteamGameResponse);
 
         // 컨트롤러 호출
         ResultActions resultActions = mvc.perform(
@@ -155,15 +164,17 @@ public class SteamAuthTest {
         );
 
         // mock 서버 검증 (API가 제대로 호출되었는지 확인)
-        mockServer.verify();
+        Mockito.verify(mockSteamOpenIdClient).validateSteamId(Mockito.any());
+        Mockito.verify(mockSteamApiClient).getPlayerOwnedGames(eq(apikey),Mockito.any());
+        Mockito.verify(mockSteamApiClient).getPlayerSummaries(eq(apikey),Mockito.any());
     }
 
     @Test
     @DisplayName("스팀 회원가입 실패 테스트, 스팀 id 123, sampleUser1")
     void test2() throws Exception {
         // 가짜 API 응답 설정
-        mockServer.expect(requestTo("https://steamcommunity.com/openid/login"))
-                .andRespond(withSuccess("is_valid:true", MediaType.TEXT_PLAIN));
+        Mockito.when(mockSteamOpenIdClient.validateSteamId(Mockito.any()))
+                .thenReturn("is_valid:true");
 
         // 컨트롤러 호출
         ResultActions resultActions = mvc.perform(
@@ -177,15 +188,15 @@ public class SteamAuthTest {
         resultActions.andExpect(status().isConflict());
 
         // mock 서버 검증 (API 가 제대로 호출되었는지 확인)
-        mockServer.verify();
+        Mockito.verify(mockSteamOpenIdClient).validateSteamId(Mockito.any());
     }
 
     @Test
     @DisplayName("스팀 로그인 실패 테스트, 스팀 id 1234, 새로운 사용자")
     void loginNewUser() throws Exception {
         // 가짜 API 응답 설정
-        mockServer.expect(requestTo("https://steamcommunity.com/openid/login"))
-                .andRespond(withSuccess("is_valid:true", MediaType.TEXT_PLAIN));
+        Mockito.when(mockSteamOpenIdClient.validateSteamId(Mockito.any()))
+                .thenReturn("is_valid:true");
 
         // 컨트롤러 호출
         ResultActions resultActions = mvc.perform(
@@ -199,7 +210,7 @@ public class SteamAuthTest {
         resultActions.andExpect(status().isNotFound());
 
         // mock 서버 검증 (API 가 제대로 호출되었는지 확인)
-        mockServer.verify();
+        Mockito.verify(mockSteamOpenIdClient).validateSteamId(Mockito.any());
     }
 
     @Test
@@ -207,13 +218,28 @@ public class SteamAuthTest {
     void linkNoSteamMember() throws Exception {
         long initCount = memberSteamDataRepository.count();
         // 가짜 API 응답 설정
-        mockServer.expect(requestTo("https://steamcommunity.com/openid/login"))
-                .andRespond(withSuccess("is_valid:true", MediaType.TEXT_PLAIN));
+        Mockito.when(mockSteamOpenIdClient.validateSteamId(Mockito.any()))
+                .thenReturn("is_valid:true");
 
         // 가짜 게임 리스트 응답 설정
-        String fakeGameListResponse = "{ \"response\": { \"games\": [ { \"appid\": 123 }, { \"appid\": 456 } ] } }";
-        mockServer.expect(requestTo(String.format("https://api.steampowered.com/IPlayerService/GetOwnedGames/v1/?key=%s&steamid=1234",apikey)))
-                .andRespond(withSuccess(fakeGameListResponse, MediaType.APPLICATION_JSON));
+        SteamGameResponse fakeSteamGameResponse = new SteamGameResponse();
+        GameResponse gameResponse = new GameResponse();
+        Game game1 = new Game();
+        Game game2 = new Game();
+        Game game3 = new Game();
+
+        game1.setAppId("2246340");
+        game1.setPlaytime(111);
+        game2.setAppId("2680010");
+        game2.setPlaytime(222);
+        game3.setAppId("2456740");
+        game3.setPlaytime(333);
+
+        gameResponse.setGames(List.of(game1, game2, game3));
+        fakeSteamGameResponse.setResponse(gameResponse);
+
+        Mockito.when(mockSteamApiClient.getPlayerOwnedGames(eq(apikey),Mockito.any()))
+                .thenReturn(fakeSteamGameResponse);
 
         // 컨트롤러 호출
         MockHttpServletRequestBuilder request = get("/api/auth/steam/callback/link")
@@ -228,10 +254,11 @@ public class SteamAuthTest {
 
         // count가 3 증가했는지 검증
         long finalCount = memberSteamDataRepository.count();
-        assertEquals(initCount + 2, finalCount);
+        assertEquals(initCount + 3, finalCount);
 
         // mock 서버 검증 (API가 제대로 호출되었는지 확인)
-        mockServer.verify();
+        Mockito.verify(mockSteamOpenIdClient).validateSteamId(Mockito.any());
+        Mockito.verify(mockSteamApiClient).getPlayerOwnedGames(eq(apikey),Mockito.any());
     }
 }
 

--- a/src/test/java/com/ll/playon/domain/member/controller/SteamAuthTest.java
+++ b/src/test/java/com/ll/playon/domain/member/controller/SteamAuthTest.java
@@ -4,6 +4,7 @@ import com.ll.playon.domain.member.TestMemberHelper;
 import com.ll.playon.domain.member.repository.MemberSteamDataRepository;
 import com.ll.playon.global.openFeign.SteamApiClient;
 import com.ll.playon.global.openFeign.SteamOpenIdClient;
+import com.ll.playon.global.openFeign.SteamStoreClient;
 import com.ll.playon.global.openFeign.dto.*;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
@@ -24,6 +25,7 @@ import org.springframework.util.LinkedMultiValueMap;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,6 +53,9 @@ public class SteamAuthTest {
 
     @MockitoBean
     private SteamApiClient mockSteamApiClient;
+
+    @MockitoBean
+    private SteamStoreClient mockSteamStoreClient;
 
     @Value("${custom.steam.apikey}")
     private String apikey;
@@ -134,6 +139,22 @@ public class SteamAuthTest {
 
         Mockito.when(mockSteamApiClient.getPlayerOwnedGames(eq(apikey),Mockito.any()))
                 .thenReturn(fakeSteamGameResponse);
+
+        // 가짜 게임 장르 응답 설정
+        SteamGameDetailResponse fakeSteamGameDetailResponse = new SteamGameDetailResponse();
+        GameDetailWrapper gameDetailWrapper = new GameDetailWrapper();
+        GameDetail gameDetail = new GameDetail();
+        Genre genre = new Genre();
+
+        genre.setId("1");
+        genre.setDescription("Action");
+
+        gameDetail.setGenres(List.of(genre));
+        gameDetailWrapper.setGameData(gameDetail);
+        fakeSteamGameDetailResponse.setGames(Map.of("123", gameDetailWrapper));
+
+        Mockito.when(mockSteamStoreClient.getGameDetail(Mockito.any(),Mockito.any(),Mockito.any()))
+                .thenReturn(fakeSteamGameDetailResponse);
 
         // 컨트롤러 호출
         ResultActions resultActions = mvc.perform(
@@ -240,6 +261,22 @@ public class SteamAuthTest {
 
         Mockito.when(mockSteamApiClient.getPlayerOwnedGames(eq(apikey),Mockito.any()))
                 .thenReturn(fakeSteamGameResponse);
+
+        // 가짜 게임 장르 응답 설정
+        SteamGameDetailResponse fakeSteamGameDetailResponse = new SteamGameDetailResponse();
+        GameDetailWrapper gameDetailWrapper = new GameDetailWrapper();
+        GameDetail gameDetail = new GameDetail();
+        Genre genre = new Genre();
+
+        genre.setId("1");
+        genre.setDescription("Action");
+
+        gameDetail.setGenres(List.of(genre));
+        gameDetailWrapper.setGameData(gameDetail);
+        fakeSteamGameDetailResponse.setGames(Map.of("123", gameDetailWrapper));
+
+        Mockito.when(mockSteamStoreClient.getGameDetail(Mockito.any(),Mockito.any(),Mockito.any()))
+                .thenReturn(fakeSteamGameDetailResponse);
 
         // 컨트롤러 호출
         MockHttpServletRequestBuilder request = get("/api/auth/steam/callback/link")


### PR DESCRIPTION
1. RestTemplate 를 대체하여 OpenFeign 을 도입하였습니다.

2. 사용자가 소유한 게임을 통해 사용자의 선호 장르를 계산합니다.