### PR TITLE
[FEAT] PartyLog 엔티티 개설 및 파티 로그 작성

### DIFF
--- a/src/main/java/com/ll/playon/domain/image/entity/Image.java
+++ b/src/main/java/com/ll/playon/domain/image/entity/Image.java
@@ -15,10 +15,10 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(
-        name = "images",
-        indexes = @Index(
-                name = "idx_img",
-                columnList = "referenceId, imageType")
+        name = "image",
+        indexes = {
+                @Index(name = "idx_image_reference_id_image_type", columnList = "referenceId, imageType")
+        }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/ll/playon/domain/image/mapper/ImageMapper.java
+++ b/src/main/java/com/ll/playon/domain/image/mapper/ImageMapper.java
@@ -8,6 +8,7 @@ public class ImageMapper {
         return Image.builder()
                 .imageUrl(imageUrl)
                 .referenceId(referenceId)
+                .imageType(imageType)
                 .build();
     }
 }

--- a/src/main/java/com/ll/playon/domain/image/service/ImageService.java
+++ b/src/main/java/com/ll/playon/domain/image/service/ImageService.java
@@ -16,7 +16,7 @@ import org.springframework.util.CollectionUtils;
 public class ImageService {
     private final ImageRepository imageRepository;
 
-    // 이미지 DB에 저장
+    // 이미지 리스트 DB에 저장
     @Transactional
     public void saveImages(ImageType imageType, long referenceId, List<String> urls) {
         List<Image> images = urls.stream()
@@ -24,6 +24,12 @@ public class ImageService {
                 .toList();
 
         this.imageRepository.saveAll(images);
+    }
+
+    // 이미지 DB에 저장
+    @Transactional
+    public void saveImage(ImageType imageType, long referenceId, String url) {
+        this.imageRepository.save(ImageMapper.of(url, referenceId, imageType));
     }
 
     // Id로 이미지 목록 호출

--- a/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
@@ -10,12 +10,18 @@ import com.ll.playon.global.security.UserContext;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/members")

--- a/src/main/java/com/ll/playon/domain/party/party/context/PartyMemberContext.java
+++ b/src/main/java/com/ll/playon/domain/party/party/context/PartyMemberContext.java
@@ -1,0 +1,21 @@
+package com.ll.playon.domain.party.party.context;
+
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PartyMemberContext {
+    private static final ThreadLocal<PartyMember> currentPartyMember = new ThreadLocal<>();
+
+    public static PartyMember getPartyMember() {
+        return currentPartyMember.get();
+    }
+
+    public static void setPartyMember(PartyMember partyMember) {
+        currentPartyMember.set(partyMember);
+    }
+
+    public static void clear() {
+        currentPartyMember.remove();
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
+++ b/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
@@ -6,6 +6,7 @@ import com.ll.playon.domain.party.party.dto.request.PostPartyRequest;
 import com.ll.playon.domain.party.party.dto.request.PutPartyRequest;
 import com.ll.playon.domain.party.party.dto.response.GetAllPendingMemberResponse;
 import com.ll.playon.domain.party.party.dto.response.GetPartyDetailResponse;
+import com.ll.playon.domain.party.party.dto.response.GetPartyMainResponse;
 import com.ll.playon.domain.party.party.dto.response.GetPartyResponse;
 import com.ll.playon.domain.party.party.dto.response.PostPartyResponse;
 import com.ll.playon.domain.party.party.dto.response.PutPartyResponse;
@@ -39,8 +40,6 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "PartyController")
 public class PartyController {
     private final PartyService partyService;
-
-    // TODO : 인증된 사용자로 변경
     private final UserContext userContext;
 
     @PostMapping
@@ -71,6 +70,16 @@ public class PartyController {
 
         return RsData.success(HttpStatus.OK,
                 new PageDto<>(this.partyService.getAllParties(page, pageSize, orderBy, partyAt, getAllPartiesRequest)));
+    }
+
+    @GetMapping("/main")
+    @Operation(summary = "파티 메인용 리스트 조회")
+    public RsData<GetPartyMainResponse> getPartyMain(@RequestParam(defaultValue = "2") int limit) {
+        // TODO : 추후 롤백
+//        정책 고민 (회원만 조회 가능하게 할 것인지)
+//        Member actor = this.userContext.getActor();
+
+        return RsData.success(HttpStatus.OK, this.partyService.getPartyMain(limit));
     }
 
     @GetMapping("/{partyId}")
@@ -146,5 +155,16 @@ public class PartyController {
         Member actor = this.userContext.findById(5L);
 
         return RsData.success(HttpStatus.OK, this.partyService.getPartyPendingMembers(actor, partyId));
+    }
+
+    @PostMapping("/{partyId}/members/{memberId}/invitation")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "파티 초대")
+    public void inviteParty(@PathVariable long partyId, @PathVariable long memberId) {
+        // TODO : 추후 롤백
+//        Member actor = this.userContext.getActor();
+        Member actor = this.userContext.findById(5L);
+
+        this.partyService.inviteParty(actor, partyId, memberId);
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/dto/response/GetPartyMainResponse.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/response/GetPartyMainResponse.java
@@ -1,0 +1,10 @@
+package com.ll.playon.domain.party.party.dto.response;
+
+import java.util.List;
+import lombok.NonNull;
+
+public record GetPartyMainResponse(
+        @NonNull
+        List<GetPartyResponse> parties
+) {
+}

--- a/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
@@ -1,12 +1,16 @@
 package com.ll.playon.domain.party.party.entity;
 
+import static jakarta.persistence.GenerationType.IDENTITY;
+
 import com.ll.playon.domain.party.party.type.PartyStatus;
-import com.ll.playon.global.jpa.entity.BaseTime;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -18,18 +22,27 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(
         name = "party",
         indexes = {
-                @Index(name = "idx_party_status_partyAt", columnList = "partyStatus, partyAt")
+                @Index(name = "idx_party_status_party_at_created_at", columnList = "partyStatus, partyAt, createdAt")
         }
 )
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Party extends BaseTime {
+@EntityListeners(AuditingEntityListener.class)
+public class Party {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Setter(AccessLevel.PROTECTED)
+    private Long id;
+
     // TODO : Game 엔티티 개설되면 연결
     @Column(nullable = false)
 //    @ManyToOne(fetch = FetchType.LAZY)
@@ -66,6 +79,14 @@ public class Party extends BaseTime {
 
     @OneToMany(mappedBy = "party", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PartyTag> partyTags = new ArrayList<>();
+
+    @CreatedDate
+    @Setter(AccessLevel.PRIVATE)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Setter(AccessLevel.PRIVATE)
+    private LocalDateTime modifiedAt;
 
     // TODO : 파티 룸
 

--- a/src/main/java/com/ll/playon/domain/party/party/entity/PartyMember.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/PartyMember.java
@@ -2,7 +2,9 @@ package com.ll.playon.domain.party.party.entity;
 
 import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.party.party.type.PartyRole;
+import com.ll.playon.domain.party.partyLog.entity.PartyLog;
 import com.ll.playon.global.jpa.entity.BaseTime;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,6 +12,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,7 +22,7 @@ import lombok.Setter;
 
 @Entity
 @Table(
-        name = "party_members",
+        name = "party_member",
         indexes = {
                 @Index(name = "idx_party_member_party_id_role", columnList = "party_id, partyRole")
         }
@@ -38,12 +41,25 @@ public class PartyMember extends BaseTime {
     @Column(nullable = false)
     private PartyRole partyRole;
 
-    // TODO: 파티 로그
+    @Column(nullable = false)
+    private Integer mvpPoint;
+
+    @OneToOne(mappedBy = "partyMember", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private PartyLog partyLog;
 
     @Builder
-    public PartyMember(Member member, PartyRole partyRole) {
+    public PartyMember(Member member, PartyRole partyRole, Integer mvpPoint) {
         this.member = member;
         this.partyRole = partyRole;
+        this.mvpPoint = mvpPoint;
+    }
+
+    public void voteMvp() {
+        ++this.mvpPoint;
+    }
+
+    public boolean isOwn(Member member) {
+        return this.party != null && this.member.equals(member);
     }
 
     public void delete() {

--- a/src/main/java/com/ll/playon/domain/party/party/entity/PartyTag.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/PartyTag.java
@@ -21,7 +21,7 @@ import lombok.Setter;
 
 @Entity
 @Table(
-        name = "party_tags",
+        name = "party_tag",
         indexes = {
                 @Index(name = "idx_party_tag_party_id_value", columnList = "party_id, tag_value"),
         }

--- a/src/main/java/com/ll/playon/domain/party/party/mapper/PartyMemberMapper.java
+++ b/src/main/java/com/ll/playon/domain/party/party/mapper/PartyMemberMapper.java
@@ -9,6 +9,7 @@ public class PartyMemberMapper {
         return PartyMember.builder()
                 .member(actor)
                 .partyRole(partyRole)
+                .mvpPoint(0)
                 .build();
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -3,6 +3,7 @@ package com.ll.playon.domain.party.party.repository;
 import com.ll.playon.domain.party.party.entity.Party;
 import com.ll.playon.domain.party.party.entity.PartyMember;
 import com.ll.playon.domain.party.party.entity.PartyTag;
+import com.ll.playon.domain.party.party.type.PartyStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -104,4 +105,6 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             AND pm.partyRole <> 'PENDING'
             """)
     List<PartyMember> findPartyMembersByPartyIds(@Param("partyIds") List<Long> partyIds);
+
+    List<Party> findAllByPartyStatusOrderByPartyAtDescCreatedAtDesc(PartyStatus partyStatus, Pageable pageable);
 }

--- a/src/main/java/com/ll/playon/domain/party/party/type/PartyRole.java
+++ b/src/main/java/com/ll/playon/domain/party/party/type/PartyRole.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum PartyRole {
     OWNER("생성자"),
     MEMBER("참여자"),
-    PENDING("신청자");
+    PENDING("대기자");
 
     private final String value;
 }

--- a/src/main/java/com/ll/playon/domain/party/party/validation/PartyMemberValidation.java
+++ b/src/main/java/com/ll/playon/domain/party/party/validation/PartyMemberValidation.java
@@ -1,15 +1,16 @@
 package com.ll.playon.domain.party.party.validation;
 
+import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.party.party.entity.PartyMember;
 import com.ll.playon.domain.party.party.type.PartyRole;
 import com.ll.playon.global.exceptions.ErrorCode;
 
 public class PartyMemberValidation {
 
-    // 파티장인지 확인
-    public static void checkPartyOwner(PartyMember partyMember) {
-        if (partyMember.getPartyRole().equals(PartyRole.OWNER)) {
-            ErrorCode.PARTY_OWNER_CANNOT_APPLY.throwServiceException();
+    // 해당 파티멤버가 본인 자신인지 확인
+    public static void checkIsPartyMemberOwn(PartyMember partyMember, Member actor) {
+        if (partyMember.isOwn(actor)) {
+            ErrorCode.IS_PARTY_MEMBER_OWN.throwServiceException();
         }
     }
 

--- a/src/main/java/com/ll/playon/domain/party/partyLog/PartyLogRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/PartyLogRepository.java
@@ -1,0 +1,7 @@
+package com.ll.playon.domain.party.partyLog;
+
+import com.ll.playon.domain.party.partyLog.entity.PartyLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PartyLogRepository extends JpaRepository<PartyLog, Long> {
+}

--- a/src/main/java/com/ll/playon/domain/party/partyLog/controller/PartyLogController.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/controller/PartyLogController.java
@@ -1,0 +1,50 @@
+package com.ll.playon.domain.party.partyLog.controller;
+
+import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.party.partyLog.dto.request.PostPartyLogRequest;
+import com.ll.playon.domain.party.partyLog.dto.response.PostPartyLogResponse;
+import com.ll.playon.domain.party.partyLog.service.PartyLogService;
+import com.ll.playon.global.response.RsData;
+import com.ll.playon.global.security.UserContext;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/logs")
+@Tag(name = "PartyLogController")
+public class PartyLogController {
+    private final PartyLogService partyLogService;
+    private final UserContext userContext;
+
+    @PostMapping("/party/{partyId}")
+    @Operation(summary = "파티 로그 작성")
+    public RsData<PostPartyLogResponse> createPartyLog(@PathVariable long partyId,
+                                                       @RequestBody @Valid PostPartyLogRequest request) {
+        // TODO : 추후 롤백
+//        Member actor = this.userContext.getActor();
+        Member actor = this.userContext.findById(5L);
+
+        return RsData.success(HttpStatus.CREATED, this.partyLogService.createPartyLog(actor, partyId, request));
+    }
+
+    @PostMapping("/{logId}/party/{partyId}/screenshot")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "스크린샷 URL 저장")
+    public void saveImageUrl(@PathVariable long logId, @PathVariable long partyId, @RequestBody String url) {
+        // TODO : 추후 롤백
+//        Member actor = this.userContext.getActor();
+        Member actor = this.userContext.findById(5L);
+
+        this.partyLogService.saveImageUrl(actor, partyId, logId, url);
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/partyLog/dto/request/PostPartyLogRequest.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/dto/request/PostPartyLogRequest.java
@@ -1,0 +1,23 @@
+package com.ll.playon.domain.party.partyLog.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
+
+public record PostPartyLogRequest(
+        @NotNull
+        String comment,
+
+        @NotNull
+        String content,
+
+        @NotNull
+        String fileType,
+
+        Long partyMemberId
+) {
+    public PostPartyLogRequest {
+        comment = Objects.requireNonNullElse(comment, "");
+        content = Objects.requireNonNullElse(content, "");
+        fileType = Objects.requireNonNullElse(fileType, "");
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/partyLog/dto/response/PostPartyLogResponse.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/dto/response/PostPartyLogResponse.java
@@ -1,0 +1,12 @@
+package com.ll.playon.domain.party.partyLog.dto.response;
+
+import java.net.URL;
+
+public record PostPartyLogResponse(
+        long logId,
+
+        long partyId,
+
+        URL presignedUrl
+) {
+}

--- a/src/main/java/com/ll/playon/domain/party/partyLog/entity/PartyLog.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/entity/PartyLog.java
@@ -1,0 +1,35 @@
+package com.ll.playon.domain.party.partyLog.entity;
+
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.global.jpa.entity.BaseTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PartyLog extends BaseTime {
+    @OneToOne(fetch = FetchType.LAZY)
+    private PartyMember partyMember;
+
+    @Column(columnDefinition = "TEXT")
+    private String comment;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Builder
+    public PartyLog(PartyMember partyMember, String comment, String content) {
+        this.partyMember = partyMember;
+        this.comment = comment;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/partyLog/mapper/PartyLogMapper.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/mapper/PartyLogMapper.java
@@ -1,0 +1,15 @@
+package com.ll.playon.domain.party.partyLog.mapper;
+
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.domain.party.partyLog.dto.request.PostPartyLogRequest;
+import com.ll.playon.domain.party.partyLog.entity.PartyLog;
+
+public class PartyLogMapper {
+    public static PartyLog of(PartyMember partyMember, PostPartyLogRequest postPartyLogRequest) {
+        return PartyLog.builder()
+                .partyMember(partyMember)
+                .comment(postPartyLogRequest.comment())
+                .content(postPartyLogRequest.content())
+                .build();
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/partyLog/service/PartyLogService.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/service/PartyLogService.java
@@ -1,0 +1,71 @@
+package com.ll.playon.domain.party.partyLog.service;
+
+import com.ll.playon.domain.image.service.ImageService;
+import com.ll.playon.domain.image.type.ImageType;
+import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.party.party.context.PartyContext;
+import com.ll.playon.domain.party.party.context.PartyMemberContext;
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.domain.party.party.repository.PartyMemberRepository;
+import com.ll.playon.domain.party.party.validation.PartyMemberValidation;
+import com.ll.playon.domain.party.partyLog.PartyLogRepository;
+import com.ll.playon.domain.party.partyLog.dto.request.PostPartyLogRequest;
+import com.ll.playon.domain.party.partyLog.dto.response.PostPartyLogResponse;
+import com.ll.playon.domain.party.partyLog.entity.PartyLog;
+import com.ll.playon.domain.party.partyLog.mapper.PartyLogMapper;
+import com.ll.playon.domain.party.partyLog.validation.PartyLogValidation;
+import com.ll.playon.global.annotation.ActivePartyMemberOnly;
+import com.ll.playon.global.aws.s3.S3Service;
+import com.ll.playon.global.exceptions.ErrorCode;
+import java.net.URL;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PartyLogService {
+    private final ImageService imageService;
+    private final S3Service s3Service;
+    private final PartyLogRepository partyLogRepository;
+    private final PartyMemberRepository partyMemberRepository;
+
+    // 파티 로그 작성
+    // AOP로 권한 체크
+    @ActivePartyMemberOnly
+    @Transactional
+    public PostPartyLogResponse createPartyLog(Member actor, long partyId, PostPartyLogRequest request) {
+        Party party = PartyContext.getParty();
+        PartyMember partyMember = PartyMemberContext.getPartyMember();
+
+        PartyLogValidation.checkIsPartyLogNotCreated(partyMember);
+        PartyLogValidation.checkIsPartyEnd(party);
+
+        PartyLog partyLog = this.partyLogRepository.save(PartyLogMapper.of(partyMember, request));
+
+        // Mvp를 투표한 경우
+        if (request.partyMemberId() != null) {
+            PartyMember mvpCandidate = this.partyMemberRepository.findById(request.partyMemberId())
+                    .orElseThrow(ErrorCode.PARTY_MEMBER_NOT_FOUND::throwServiceException);
+
+            mvpCandidate.voteMvp();
+        }
+
+        URL presignedUrl = this.s3Service.generatePresignedUrl(ImageType.LOG, partyId, request.fileType());
+
+        return new PostPartyLogResponse(partyLog.getId(), partyLog.getId(), presignedUrl);
+    }
+
+    // 스크린샷 URL 저장
+    // AOP로 권한 체크
+    @ActivePartyMemberOnly
+    public void saveImageUrl(Member actor, long partyId, long logId, String url) {
+        Party party = PartyContext.getParty();
+
+        PartyMemberValidation.checkIsPartyMemberOwn(PartyMemberContext.getPartyMember(), actor);
+        PartyLogValidation.checkIsPartyEnd(party);
+
+        this.imageService.saveImage(ImageType.LOG, logId, url);
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/partyLog/validation/PartyLogValidation.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/validation/PartyLogValidation.java
@@ -1,0 +1,22 @@
+package com.ll.playon.domain.party.partyLog.validation;
+
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.domain.party.party.type.PartyStatus;
+import com.ll.playon.global.exceptions.ErrorCode;
+
+public class PartyLogValidation {
+    // 파티가 종료되었는지 확인
+    public static void checkIsPartyEnd(Party party) {
+        if (!party.getPartyStatus().equals(PartyStatus.COMPLETED)) {
+            ErrorCode.PARTY_IS_NOT_ENDED.throwServiceException();
+        }
+    }
+
+    // 이미 파티 로그가 작성되었는지 확인
+    public static void checkIsPartyLogNotCreated(PartyMember partyMember) {
+        if (partyMember.getPartyLog() != null) {
+            ErrorCode.PARTY_LOG_ALREADY_EXISTS.throwServiceException();
+        }
+    }
+}

--- a/src/main/java/com/ll/playon/global/annotation/ActivePartyMemberOnly.java
+++ b/src/main/java/com/ll/playon/global/annotation/ActivePartyMemberOnly.java
@@ -1,0 +1,11 @@
+package com.ll.playon.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ActivePartyMemberOnly {
+}

--- a/src/main/java/com/ll/playon/global/aspect/ActivePartyMemberCheckAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/ActivePartyMemberCheckAspect.java
@@ -1,0 +1,59 @@
+package com.ll.playon.global.aspect;
+
+import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.party.party.context.PartyContext;
+import com.ll.playon.domain.party.party.context.PartyMemberContext;
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.domain.party.party.repository.PartyMemberRepository;
+import com.ll.playon.domain.party.party.repository.PartyRepository;
+import com.ll.playon.domain.party.party.type.PartyRole;
+import com.ll.playon.global.exceptions.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ActivePartyMemberCheckAspect {
+    private final PartyRepository partyRepository;
+    private final PartyMemberRepository partyMemberRepository;
+
+    @Around("@annotation(com.ll.playon.global.annotation.ActivePartyMemberOnly)")
+    public Object checkPartyMember(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object[] args = joinPoint.getArgs();
+
+        Member actor = (Member) args[0];
+        Long partyId = (Long) args[1];
+        Party party = this.partyRepository.findById(partyId)
+                .orElseThrow(ErrorCode.PARTY_NOT_FOUND::throwServiceException);
+
+        if (isNotActivePartyMember(actor, party)) {
+            throw ErrorCode.IS_NOT_PARTY_MEMBER.throwServiceException();
+        }
+
+        PartyMember partyMember = this.partyMemberRepository.findByMemberAndParty(actor, party)
+                .orElseThrow(ErrorCode.PARTY_MEMBER_NOT_FOUND::throwServiceException);
+
+        PartyContext.setParty(party);
+        PartyMemberContext.setPartyMember(partyMember);
+
+        try {
+            return joinPoint.proceed(args);
+        } finally {
+            PartyContext.clear();
+            PartyMemberContext.clear();
+        }
+    }
+
+    private boolean isNotActivePartyMember(Member actor, Party party) {
+        return party.getPartyMembers().stream()
+                .noneMatch(pm -> pm.getMember().getId().equals(actor.getId())
+                                 && !pm.getPartyRole().equals(PartyRole.PENDING));
+    }
+}

--- a/src/main/java/com/ll/playon/global/aws/s3/S3Service.java
+++ b/src/main/java/com/ll/playon/global/aws/s3/S3Service.java
@@ -45,7 +45,7 @@ public class S3Service {
     }
 
     // PresignedURL 생성
-    private URL generatePresignedUrl(ImageType imageType, long referenceId, String fileType) {
+    public URL generatePresignedUrl(ImageType imageType, long referenceId, String fileType) {
         try {
             // PresignedURL 생성
             return s3Presigner.presignPutObject(builder -> builder

--- a/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
@@ -66,11 +66,16 @@ public enum ErrorCode {
 
     // PartyMember
     IS_NOT_PARTY_OWNER(HttpStatus.FORBIDDEN, "해당 파티의 파티장이 아닙니다."),
+    IS_NOT_PARTY_MEMBER(HttpStatus.FORBIDDEN, "해당 파티의 파티원이 아닙니다."),
     IS_ALREADY_PARTY_MEMBER(HttpStatus.FORBIDDEN, "이미 해당 파티의 파티원입니다."),
-    PARTY_OWNER_CANNOT_APPLY(HttpStatus.FORBIDDEN, "파티장은 파티에 신청할 수 없습니다."),
+    IS_PARTY_MEMBER_OWN(HttpStatus.FORBIDDEN, "본인 스스로에 대한 처리는 불가능합니다."),
     PARTY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "파티 멤버가 존재하지 않습니다."),
     PARTY_OWNER_NOT_FOUND(HttpStatus.NOT_FOUND, "파티장이 존재하지 않습니다."),
     PENDING_PARTY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "파티 참가를 신청한 사용자가 아닙니다."),
+
+    // PartyLog
+    PARTY_LOG_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 파티 로그를 작성하셨습니다."),
+    PARTY_IS_NOT_ENDED(HttpStatus.BAD_REQUEST, "파티가 종료되지 않았습니다."),
 
     // Tag
     TAG_TYPE_CONVERT_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "태그 타입 변환에 실패하였습니다."),

--- a/src/main/java/com/ll/playon/global/security/UserContext.java
+++ b/src/main/java/com/ll/playon/global/security/UserContext.java
@@ -2,6 +2,7 @@ package com.ll.playon.global.security;
 
 import com.ll.playon.domain.member.service.MemberService;
 import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.global.exceptions.ErrorCode;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -131,6 +132,7 @@ public class UserContext {
      * 테스트용, 추후 삭제
      */
     public Member findById(long id) {
-        return this.memberService.findById(id).get();
+        return this.memberService.findById(id)
+                .orElseThrow(ErrorCode.USER_NOT_REGISTERED::throwServiceException);
     }
 }


### PR DESCRIPTION
closes #43, #44 

## 1. PartyLog 엔티티 추가
- `PartyLog` 엔티티 추가 및 `Party` 엔티티에도 반영

## 2. PartyLog 작성
- 로그 작성 구현
- 로그 작성 시 mvp 투표를 진행했으면, 이를 반영
- 로그 작성 시 이미지가 있으면
- `Postman` 을 통한 1차 테스트 완료

## 3. `AOP` 로 인가 적용
- `@ActivePartyMemberOnly` 어노테이션 추가
- `PartyMemberContext` 추가 개설 및 `ThreadLocal` 사용
- `AOP` 를 사용해서 해당 어노테이션으로 해당 파티의 파티원인지 인가 진행
  - `PENDING` 상태의 파티원이어도 비허용

## 4. 기존 코드 리팩토링
- 중복 코드 리팩토링
- 파티 로그 이미지 업로드 및 경로를 로컬 DB에 저장
- `Party` 관련 테이블들 이름 수정
  - 복수형 -> 단수형
- `Image.Builder` 수정
  - `ImageType` 추가 반영
- 단일 이미지 저장 로직 분리
- `Party` 엔티티의 상속 취소 및 해당 필드들 개별로 추가
  - 기존 `createdAt` 필드에 `Null` 이 들어가던 문제 해결