### PR TITLE
[FEAT] 파티 로그 수정 및 삭제 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,73 +1,76 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.2'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.2'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.example.playOn'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
-	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.2.1'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.2.1'
 
-	// OpenAPI (Swagger) 추가
-	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1"
+    // OpenAPI (Swagger) 추가
+    implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1"
 
-	// 외부 api 호출을 위함 (WebClient)
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    // 외부 api 호출을 위함 (WebClient)
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-	// AWS S3
-	implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.3.0'
-  	implementation 'software.amazon.awssdk:s3:2.31.11'
+    // AWS S3
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.3.0'
+    implementation 'software.amazon.awssdk:s3:2.31.11'
 
-	// QueryDSL
-	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
-	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
-	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
-	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
-	// spring batch
-	implementation 'org.springframework.boot:spring-boot-starter-batch'
+    // spring batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
 
-	// jackson
-	implementation 'com.fasterxml.jackson.core:jackson-databind'
+    // jackson
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    // EventListener
+    implementation 'org.springframework.retry:spring-retry'
 
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/ll/playon/domain/image/entity/Image.java
+++ b/src/main/java/com/ll/playon/domain/image/entity/Image.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Table(
         name = "image",
         indexes = {
-                @Index(name = "idx_image_reference_id_image_type", columnList = "referenceId, imageType")
+                @Index(name = "idx_image_reference_id_image_type_image_url", columnList = "referenceId, imageType, imageUrl"),
         }
 )
 @Getter

--- a/src/main/java/com/ll/playon/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/ll/playon/domain/image/repository/ImageRepository.java
@@ -25,4 +25,17 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
             @Param("imageType") ImageType imageType,
             @Param("referenceId") long referenceId,
             @Param("imageUrls") List<String> imageUrls);
+
+    @Modifying
+    @Query("""
+            DELETE FROM Image i
+            WHERE i.referenceId = :referenceId
+            And i.imageType = :imageType
+            AND i.imageUrl = :imageUrl
+            """
+    )
+    long deleteByReferenceIdAndImageUrl(
+            @Param("imageType") ImageType imageType,
+            @Param("referenceId") long referenceId,
+            @Param("imageUrl") String imageUrl);
 }

--- a/src/main/java/com/ll/playon/domain/party/party/validation/PartyMemberValidation.java
+++ b/src/main/java/com/ll/playon/domain/party/party/validation/PartyMemberValidation.java
@@ -14,6 +14,13 @@ public class PartyMemberValidation {
         }
     }
 
+    // 해당 파티멤버가 본인 자신이 아닌지 확인
+    public static void checkIsNotPartyMemberOwn(PartyMember partyMember, Member actor) {
+        if (!partyMember.isOwn(actor)) {
+            ErrorCode.IS_NOT_PARTY_MEMBER_OWN.throwServiceException();
+        }
+    }
+
     // 이미 파티에 신청했는지 확인
     public static void checkPendingMember(PartyMember partyMember) {
         if (partyMember.getPartyRole().equals(PartyRole.PENDING)) {

--- a/src/main/java/com/ll/playon/domain/party/partyLog/controller/PartyLogController.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/controller/PartyLogController.java
@@ -2,7 +2,8 @@ package com.ll.playon.domain.party.partyLog.controller;
 
 import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.party.partyLog.dto.request.PostPartyLogRequest;
-import com.ll.playon.domain.party.partyLog.dto.response.PostPartyLogResponse;
+import com.ll.playon.domain.party.partyLog.dto.request.PutPartyLogRequest;
+import com.ll.playon.domain.party.partyLog.dto.response.PartyLogResponse;
 import com.ll.playon.domain.party.partyLog.service.PartyLogService;
 import com.ll.playon.global.response.RsData;
 import com.ll.playon.global.security.UserContext;
@@ -11,8 +12,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -28,8 +31,8 @@ public class PartyLogController {
 
     @PostMapping("/party/{partyId}")
     @Operation(summary = "파티 로그 작성")
-    public RsData<PostPartyLogResponse> createPartyLog(@PathVariable long partyId,
-                                                       @RequestBody @Valid PostPartyLogRequest request) {
+    public RsData<PartyLogResponse> createPartyLog(@PathVariable long partyId,
+                                                   @RequestBody @Valid PostPartyLogRequest request) {
         // TODO : 추후 롤백
 //        Member actor = this.userContext.getActor();
         Member actor = this.userContext.findById(5L);
@@ -46,5 +49,28 @@ public class PartyLogController {
         Member actor = this.userContext.findById(5L);
 
         this.partyLogService.saveImageUrl(actor, partyId, logId, url);
+    }
+
+    @PutMapping("/{logId}/party/{partyId}")
+    @Operation(summary = "파티 로그 수정")
+    public RsData<PartyLogResponse> updatePartyLog(@PathVariable long logId,
+                                                   @PathVariable long partyId,
+                                                   @RequestBody @Valid PutPartyLogRequest request) {
+        // TODO : 추후 롤백
+//        Member actor = this.userContext.getActor();
+        Member actor = this.userContext.findById(5L);
+
+        return RsData.success(HttpStatus.OK, this.partyLogService.updatePartyLog(actor, partyId, logId, request));
+    }
+
+    @DeleteMapping("/{logId}/party/{partyId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "파티 로그 삭제")
+    public void deletePartyLog(@PathVariable long logId, @PathVariable long partyId) {
+        // TODO : 추후 롤백
+//        Member actor = this.userContext.getActor();
+        Member actor = this.userContext.findById(5L);
+
+        this.partyLogService.deletePartyLog(actor, partyId, logId);
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/partyLog/dto/request/PutPartyLogRequest.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/dto/request/PutPartyLogRequest.java
@@ -1,22 +1,20 @@
 package com.ll.playon.domain.party.partyLog.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.Objects;
 
-public record PostPartyLogRequest(
+public record PutPartyLogRequest(
         @NotNull
         String comment,
 
         @NotNull
         String content,
 
-        @NotBlank
-        String fileType,
+        String deleteUrl,
 
-        Long partyMemberId
+        String newFileType
 ) {
-    public PostPartyLogRequest {
+    public PutPartyLogRequest {
         comment = Objects.requireNonNullElse(comment, "");
         content = Objects.requireNonNullElse(content, "");
     }

--- a/src/main/java/com/ll/playon/domain/party/partyLog/dto/response/PartyLogResponse.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/dto/response/PartyLogResponse.java
@@ -2,7 +2,7 @@ package com.ll.playon.domain.party.partyLog.dto.response;
 
 import java.net.URL;
 
-public record PostPartyLogResponse(
+public record PartyLogResponse(
         long logId,
 
         long partyId,

--- a/src/main/java/com/ll/playon/domain/party/partyLog/entity/PartyLog.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/entity/PartyLog.java
@@ -32,4 +32,9 @@ public class PartyLog extends BaseTime {
         this.comment = comment;
         this.content = content;
     }
+
+    public void delete() {
+        this.partyMember.setPartyLog(null);
+        this.partyMember = null;
+    }
 }

--- a/src/main/java/com/ll/playon/domain/party/partyLog/event/ImageDeleteEvent.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/event/ImageDeleteEvent.java
@@ -1,0 +1,6 @@
+package com.ll.playon.domain.party.partyLog.event;
+
+public record ImageDeleteEvent(
+        long logId
+) {
+}

--- a/src/main/java/com/ll/playon/domain/party/partyLog/listener/ImageEventListener.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/listener/ImageEventListener.java
@@ -1,0 +1,38 @@
+package com.ll.playon.domain.party.partyLog.listener;
+
+import com.ll.playon.domain.image.service.ImageService;
+import com.ll.playon.domain.image.type.ImageType;
+import com.ll.playon.domain.party.partyLog.event.ImageDeleteEvent;
+import com.ll.playon.global.exceptions.ErrorCode;
+import com.ll.playon.global.exceptions.EventListenerException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ImageEventListener {
+    private final ImageService imageService;
+
+    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Retryable(exceptionExpression = "#root instanceof T(java.lang.Exception)",
+            maxAttemptsExpression = "#{3}",
+            backoff = @Backoff(delay = 2000)
+    )
+    public void handleImageDelete(ImageDeleteEvent event) {
+        try {
+            this.imageService.deleteImageById(ImageType.LOG, event.logId());
+            throw new RuntimeException("이벤트 리스너 에러 테스트");
+        } catch (Exception ex) {
+            // TODO: 이벤트 실패 시 알람?
+            // TODO: 실패한 S3 삭제(처리) 방법 고안
+
+            throw new EventListenerException(ErrorCode.EVENT_LISTENER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/partyLog/repository/PartyLogRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/repository/PartyLogRepository.java
@@ -1,4 +1,4 @@
-package com.ll.playon.domain.party.partyLog;
+package com.ll.playon.domain.party.partyLog.repository;
 
 import com.ll.playon.domain.party.partyLog.entity.PartyLog;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/ll/playon/global/aspect/EventExceptionLoggingAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/EventExceptionLoggingAspect.java
@@ -1,0 +1,20 @@
+package com.ll.playon.global.aspect;
+
+import com.ll.playon.standard.util.LogUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class EventExceptionLoggingAspect {
+    @AfterThrowing(pointcut = "@annotation(org.springframework.context.event.EventListener)", throwing = "ex")
+    public void logEventException(JoinPoint joinPoint, Throwable ex) {
+        LogUtil.logError(log, joinPoint, ex);
+    }
+}

--- a/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
@@ -35,6 +35,9 @@ public enum ErrorCode {
     USER_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 가입된 사용자입니다."),
     PASSWORD_INCORRECT(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
 
+    // EventListener
+    EVENT_LISTENER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이벤트 리스너에서 오류가 발생했습니다."),
+
     // Guild
     DUPLICATE_GUILD_NAME(HttpStatus.CONFLICT, "이미 존재하는 길드 이름입니다."),
     GUILD_NOT_FOUND(HttpStatus.NOT_FOUND, "길드를 찾을 수 없습니다."),
@@ -67,8 +70,9 @@ public enum ErrorCode {
     // PartyMember
     IS_NOT_PARTY_OWNER(HttpStatus.FORBIDDEN, "해당 파티의 파티장이 아닙니다."),
     IS_NOT_PARTY_MEMBER(HttpStatus.FORBIDDEN, "해당 파티의 파티원이 아닙니다."),
+    IS_NOT_PARTY_MEMBER_OWN(HttpStatus.FORBIDDEN, "파티원 본인이 아닙니다."),
     IS_ALREADY_PARTY_MEMBER(HttpStatus.FORBIDDEN, "이미 해당 파티의 파티원입니다."),
-    IS_PARTY_MEMBER_OWN(HttpStatus.FORBIDDEN, "본인 스스로에 대한 처리는 불가능합니다."),
+    IS_PARTY_MEMBER_OWN(HttpStatus.FORBIDDEN, "파티원 본인 스스로에 대한 처리는 불가능합니다."),
     PARTY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "파티 멤버가 존재하지 않습니다."),
     PARTY_OWNER_NOT_FOUND(HttpStatus.NOT_FOUND, "파티장이 존재하지 않습니다."),
     PENDING_PARTY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "파티 참가를 신청한 사용자가 아닙니다."),
@@ -76,6 +80,7 @@ public enum ErrorCode {
     // PartyLog
     PARTY_LOG_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 파티 로그를 작성하셨습니다."),
     PARTY_IS_NOT_ENDED(HttpStatus.BAD_REQUEST, "파티가 종료되지 않았습니다."),
+    PARTY_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "파티 로그가 존재하지 않습니다."),
 
     // Tag
     TAG_TYPE_CONVERT_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "태그 타입 변환에 실패하였습니다."),

--- a/src/main/java/com/ll/playon/global/exceptions/EventListenerException.java
+++ b/src/main/java/com/ll/playon/global/exceptions/EventListenerException.java
@@ -1,0 +1,16 @@
+package com.ll.playon.global.exceptions;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class EventListenerException extends RuntimeException {
+    private final HttpStatus resultCode;
+    private final String msg;
+
+    public EventListenerException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.resultCode = errorCode.getHttpStatus();
+        this.msg = errorCode.getMessage();
+    }
+}

--- a/src/main/java/com/ll/playon/standard/util/LogUtil.java
+++ b/src/main/java/com/ll/playon/standard/util/LogUtil.java
@@ -1,6 +1,7 @@
 package com.ll.playon.standard.util;
 
 import com.ll.playon.global.app.AppConfig;
+import com.ll.playon.global.exceptions.EventListenerException;
 import com.ll.playon.global.exceptions.ServiceException;
 import com.ll.playon.global.response.RsData;
 import org.aspectj.lang.JoinPoint;
@@ -36,6 +37,10 @@ public class LogUtil {
 
         switch (ex) {
             case ServiceException exception -> {
+                status = exception.getResultCode().toString();
+                msg = exception.getMsg();
+            }
+            case EventListenerException exception -> {
                 status = exception.getResultCode().toString();
                 msg = exception.getMsg();
             }


### PR DESCRIPTION
## 1. 파티 로그 수정
- 파티 로그 수정 기능 구현
- `Postman` 으로 1차 테스트 완료
- 기존 이미지 삭제 시
  - `S3` 에서 이미지 삭제
  - **로컬 DB**에서 **조회용 URL** 삭제
- 새로운 이미지 추가 시
  - `S3` 에 이미지 추가
  - **로컬 DB**에 **조회용 URL** 추가

## 2. 파티 로그 삭제
- 파티 로그 삭제 기능 구현
- `Postman` 으로 1차 테스트 완료
- `S3` 에서 이미지 삭제
- **로컬 DB**에서 **조회용 URL** 삭제

## 3. 단일 이미지 처리 추가
- `S3` 단일 이미지 처리 추가
- **로컬 DB** 단일 이미지 처리 추가
- 단일 이미지 추가에 따른 `Image` 인덱스 재설정

## 4. 이벤트 리스너 도입
- 파티 로그 삭제에 이벤트 리스너 도입

## 5. AOP 추가
- 이벤트 리스너 도입에 따른 AOP 추가

## 이벤트 리스너 도입 이유
- `@Transactional` 은 __DB 작업__을 원자적으로 수행하기 위한 것
- `S3` 나 `Redis` 같은 외부 시스템에서의 작업까지 자동으로 **롤백** 및 **커밋**을 해주지는 않음
- 즉, `S3` 와 `DB` 는 완전히 같은 트랜잭션에 있다고 보기는 어려움

> #### 이전처럼 같은 `@Transactional` 안에 처리하는 것으로 삭제 처리를 끝냈을 경우
- `S3` 삭제가 실패하면 예외 발생
- __로컬 DB__ 트랜잭션 롤백
- `S3` 삭제 실패로 인해서 `DB` 삭제도 불가능해짐

> #### 이벤트 리스너의 `@TransactionalEventListner(phase = TransactionPhase.AFTER_COMMIT)` 을 사용하면
- `S3` 삭제에 실패하더라도, 이미 __로컬 DB__ 커밋은 완료된 상태이기 때문에 __로컬 DB__ 문제는 발생하지 않음

## 이벤트 리스너 선택 이유
1. **외부와의 트랜잭션 연결**을 위함
2. 현재 사용 중인 전역 로깅 `AOP` 와 유사한 `AOP` 를 생성해서, **예외 발생 후처리**를 어느 정도 가능
3. **추후 확장성**을 고려하면, 문제 발생 시 클라이언트에게 **알람 발송** 등의 작업을 진행할 수 있기 때문

## 이벤트 리스너 전용 로깅 확인
![이벤트 리스너 에러 처리 (로깅)](https://github.com/user-attachments/assets/6ba0c686-4ae5-4f75-870a-15dc1b839060)