### PR TITLE
[REFACTOR] 파티 조회 조건 처리 및 인덱스 개선

### DIFF
--- a/src/main/java/com/ll/playon/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/ll/playon/domain/image/repository/ImageRepository.java
@@ -11,6 +11,8 @@ import org.springframework.data.repository.query.Param;
 public interface ImageRepository extends JpaRepository<Image, Long> {
     List<Image> findAllByImageTypeAndReferenceId(ImageType imageType, long referenceId);
 
+    Image findByImageTypeAndReferenceId(ImageType imageType, long referenceId);
+
     long deleteByImageTypeAndReferenceId(ImageType imageType, long referenceId);
 
     @Modifying

--- a/src/main/java/com/ll/playon/domain/image/service/ImageService.java
+++ b/src/main/java/com/ll/playon/domain/image/service/ImageService.java
@@ -41,6 +41,14 @@ public class ImageService {
         return this.imageRepository.findAllByImageTypeAndReferenceId(imageType, referenceId);
     }
 
+    // Id로 이미지 이미지 호출
+    @Transactional(readOnly = true)
+    public String getImageById(ImageType imageType, long referenceId) {
+        Image image = this.imageRepository.findByImageTypeAndReferenceId(imageType, referenceId);
+
+        return image != null ? image.getImageUrl() : "";
+    }
+
     // DB에서 해당 Id의 이미지 전부 삭제
     @Transactional
     public void deleteAllImagesById(ImageType imageType, long referenceId) {

--- a/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
+++ b/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
@@ -87,7 +87,7 @@ public class PartyController {
         return RsData.success(HttpStatus.OK, this.partyService.getPartyResult(partyId));
     }
 
-    @GetMapping("/main")
+    @GetMapping("/main/pending")
     @Operation(summary = "메인용 진행 예정 리스트 조회")
     public RsData<GetPartyMainResponse> getPendingPartyMain(@RequestParam(defaultValue = "2") int limit) {
         // TODO : 추후 롤백
@@ -98,7 +98,7 @@ public class PartyController {
         return RsData.success(HttpStatus.OK, this.partyService.getPendingPartyMain(limit));
     }
 
-    @GetMapping("/logs/main")
+    @GetMapping("/main/completed")
     @Operation(summary = "메인용 종료된 파티 리스트 조회")
     public RsData<GetPartyMainResponse> getCompletedPartyMain(@RequestParam(defaultValue = "3") int limit) {
         // TODO : 추후 롤백

--- a/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
+++ b/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
@@ -8,6 +8,7 @@ import com.ll.playon.domain.party.party.dto.response.GetAllPendingMemberResponse
 import com.ll.playon.domain.party.party.dto.response.GetPartyDetailResponse;
 import com.ll.playon.domain.party.party.dto.response.GetPartyMainResponse;
 import com.ll.playon.domain.party.party.dto.response.GetPartyResponse;
+import com.ll.playon.domain.party.party.dto.response.GetPartyResultResponse;
 import com.ll.playon.domain.party.party.dto.response.PostPartyResponse;
 import com.ll.playon.domain.party.party.dto.response.PutPartyResponse;
 import com.ll.playon.domain.party.party.service.PartyService;
@@ -75,9 +76,20 @@ public class PartyController {
                         getAllPartiesRequest)));
     }
 
+    @GetMapping("/{partyId}/result")
+    @Operation(summary = "파티 결과 조회")
+    public RsData<GetPartyResultResponse> getPartyResult(@PathVariable long partyId) {
+        // TODO : 추후 롤백
+//        정책 고민 (회원만 조회 가능하게 할 것인지)
+//        Member actor = this.userContext.getActor();
+//        Member actor = this.userContext.findById(5L);
+
+        return RsData.success(HttpStatus.OK, this.partyService.getPartyResult(partyId));
+    }
+
     @GetMapping("/main")
     @Operation(summary = "메인용 진행 예정 리스트 조회")
-    public RsData<GetPartyMainResponse> getPartyMain(@RequestParam(defaultValue = "2") int limit) {
+    public RsData<GetPartyMainResponse> getPendingPartyMain(@RequestParam(defaultValue = "2") int limit) {
         // TODO : 추후 롤백
 //        정책 고민 (회원만 조회 가능하게 할 것인지)
 //        Member actor = this.userContext.getActor();
@@ -88,7 +100,7 @@ public class PartyController {
 
     @GetMapping("/logs/main")
     @Operation(summary = "메인용 종료된 파티 리스트 조회")
-    public RsData<GetPartyMainResponse> GetPartyLogMain(@RequestParam(defaultValue = "3") int limit) {
+    public RsData<GetPartyMainResponse> getCompletedPartyMain(@RequestParam(defaultValue = "3") int limit) {
         // TODO : 추후 롤백
 //        정책 고민 (회원만 조회 가능하게 할 것인지)
 //        Member actor = this.userContext.getActor();

--- a/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
+++ b/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
@@ -76,14 +76,24 @@ public class PartyController {
     }
 
     @GetMapping("/main")
-    @Operation(summary = "메인용 파티 리스트 조회")
+    @Operation(summary = "메인용 진행 예정 리스트 조회")
     public RsData<GetPartyMainResponse> getPartyMain(@RequestParam(defaultValue = "2") int limit) {
         // TODO : 추후 롤백
 //        정책 고민 (회원만 조회 가능하게 할 것인지)
 //        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(5L);
+//        Member actor = this.userContext.findById(5L);
 
-        return RsData.success(HttpStatus.OK, this.partyService.getPartyMain(limit));
+        return RsData.success(HttpStatus.OK, this.partyService.getPendingPartyMain(limit));
+    }
+
+    @GetMapping("/logs/main")
+    @Operation(summary = "메인용 종료된 파티 리스트 조회")
+    public RsData<GetPartyMainResponse> GetPartyLogMain(@RequestParam(defaultValue = "3") int limit) {
+        // TODO : 추후 롤백
+//        정책 고민 (회원만 조회 가능하게 할 것인지)
+//        Member actor = this.userContext.getActor();
+
+        return RsData.success(HttpStatus.OK, this.partyService.getCompletedPartyMain(limit));
     }
 
     @GetMapping("/{partyId}")

--- a/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
+++ b/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
@@ -47,7 +47,7 @@ public class PartyController {
     public RsData<PostPartyResponse> createParty(@RequestBody @Valid PostPartyRequest postPartyRequest) {
         // TODO : 추후 롤백
 //        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(5L);
+        Member actor = this.userContext.findById(6L);
 
         return RsData.success(HttpStatus.CREATED, this.partyService.createParty(actor, postPartyRequest));
     }
@@ -66,18 +66,22 @@ public class PartyController {
         // TODO : 추후 롤백
 //        정책 고민 (회원만 조회 가능하게 할 것인지)
 //        Member actor = this.userContext.getActor();
+        Member actor = this.userContext.findById(5L);
+
         GlobalValidation.checkPageSize(pageSize);
 
         return RsData.success(HttpStatus.OK,
-                new PageDto<>(this.partyService.getAllParties(page, pageSize, orderBy, partyAt, getAllPartiesRequest)));
+                new PageDto<>(this.partyService.getAllFilteredParties(actor, page, pageSize, orderBy, partyAt,
+                        getAllPartiesRequest)));
     }
 
     @GetMapping("/main")
-    @Operation(summary = "파티 메인용 리스트 조회")
+    @Operation(summary = "메인용 파티 리스트 조회")
     public RsData<GetPartyMainResponse> getPartyMain(@RequestParam(defaultValue = "2") int limit) {
         // TODO : 추후 롤백
 //        정책 고민 (회원만 조회 가능하게 할 것인지)
 //        Member actor = this.userContext.getActor();
+        Member actor = this.userContext.findById(5L);
 
         return RsData.success(HttpStatus.OK, this.partyService.getPartyMain(limit));
     }

--- a/src/main/java/com/ll/playon/domain/party/party/dto/response/GetCompletedPartyDto.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/response/GetCompletedPartyDto.java
@@ -1,0 +1,54 @@
+package com.ll.playon.domain.party.party.dto.response;
+
+import com.ll.playon.domain.party.party.dto.PartyDetailMemberDto;
+import com.ll.playon.domain.party.party.dto.PartyDetailTagDto;
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.standard.time.dto.TotalPlayTimeDto;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.NonNull;
+
+public record GetCompletedPartyDto(
+        long partyId,
+
+        @NotBlank
+        String name,
+
+        @NonNull
+        String mvpName,
+
+        @NonNull
+        String mvpProfileImg,
+
+        @NonNull
+        LocalDateTime partyAt,
+
+        @NonNull
+        TotalPlayTimeDto playTime,
+
+        @NonNull
+        List<PartyDetailMemberDto> partyMembers,
+
+        @NonNull
+        List<PartyDetailTagDto> partyTags
+
+        // TODO: 1. 스팀 헤더 사진 추가
+        //       2. 채팅 룸 여기에?
+) {
+    public GetCompletedPartyDto(Party party, PartyMember mvp, TotalPlayTimeDto playTime,
+                                List<PartyDetailMemberDto> partyMembers,
+                                List<PartyDetailTagDto> partyTags) {
+        this(
+                party.getId(),
+                party.getName(),
+                mvp.getMember().getNickname(),
+                mvp.getMember().getProfileImg(),
+                party.getPartyAt(),
+                playTime,
+                partyMembers,
+                partyTags
+        );
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/party/dto/response/GetPartyResponse.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/response/GetPartyResponse.java
@@ -5,7 +5,6 @@ import com.ll.playon.domain.party.party.dto.PartyDetailTagDto;
 import com.ll.playon.domain.party.party.entity.Party;
 import com.ll.playon.domain.party.party.entity.PartyMember;
 import com.ll.playon.domain.party.party.entity.PartyTag;
-import com.ll.playon.domain.party.party.type.PartyRole;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -40,9 +39,7 @@ public record GetPartyResponse(
                 party.getName(),
                 party.getDescription(),
                 party.getPartyAt(),
-                (int) memberDtos.stream()
-                        .filter(pm -> !pm.getPartyRole().equals(PartyRole.PENDING))
-                        .count(),
+                party.getTotal(),
                 memberDtos.stream()
                         .map(PartyDetailMemberDto::new)
                         .toList(),

--- a/src/main/java/com/ll/playon/domain/party/party/dto/response/GetPartyResultResponse.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/response/GetPartyResultResponse.java
@@ -1,0 +1,10 @@
+package com.ll.playon.domain.party.party.dto.response;
+
+import com.ll.playon.domain.party.partyLog.dto.response.GetAllPartyLogResponse;
+
+public record GetPartyResultResponse(
+        GetCompletedPartyDto partyDetail,
+
+        GetAllPartyLogResponse partyLogs
+) {
+}

--- a/src/main/java/com/ll/playon/domain/party/party/dto/response/PostPartyResponse.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/response/PostPartyResponse.java
@@ -33,7 +33,7 @@ public record PostPartyResponse(
                 party.getGame(),
                 party.getName(),
                 party.getDescription(),
-                party.isPublic(),
+                party.isPublicFlag(),
                 party.getMinimum(),
                 party.getMaximum(),
                 PartyTagResponse.fromList(party.getPartyTags())

--- a/src/main/java/com/ll/playon/domain/party/party/dto/response/PutPartyResponse.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/response/PutPartyResponse.java
@@ -31,7 +31,7 @@ public record PutPartyResponse(
                 party.getGame(),
                 party.getName(),
                 party.getDescription(),
-                party.isPublic(),
+                party.isPublicFlag(),
                 party.getMinimum(),
                 party.getMaximum(),
                 PartyTagResponse.fromList(party.getPartyTags())

--- a/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
@@ -2,6 +2,7 @@ package com.ll.playon.domain.party.party.entity;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.ll.playon.domain.party.party.dto.request.PutPartyRequest;
 import com.ll.playon.domain.party.party.type.PartyStatus;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -124,7 +125,17 @@ public class Party {
         this.total -= 1;
     }
 
-    public void closeParTy() {
+    public void update(PutPartyRequest request) {
+        this.name = request.name();
+        this.description = request.description() != null ? request.description() : "";
+        this.partyAt = request.partyAt();
+        this.publicFlag = request.isPublic();
+        this.minimum = request.minimum();
+        this.maximum = request.maximum();;
+        this.game = request.game();
+    }
+
+    public void closeParty() {
         this.endedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
@@ -30,7 +30,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(
         name = "party",
         indexes = {
-                @Index(name = "idx_party_status_party_at_created_at", columnList = "partyStatus, partyAt, createdAt")
+                @Index(name = "idx_party_status_public_party_at_created_at", columnList = "partyStatus, is_public, party_at, created_at"),
+                @Index(name = "idx_party_status_public_party_at_id", columnList = "partyStatus, is_public, party_at, id"),
         }
 )
 @Getter
@@ -59,7 +60,7 @@ public class Party {
     private LocalDateTime partyAt;
 
     @Column(name = "is_public", nullable = false)
-    private boolean isPublic;
+    private boolean publicFlag;
 
     @Column(nullable = false)
     private long hit;
@@ -69,6 +70,9 @@ public class Party {
 
     @Column(nullable = false)
     private int maximum;
+
+    @Column(nullable = false)
+    private int total;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -91,21 +95,29 @@ public class Party {
     // TODO : 파티 룸
 
     @Builder
-    public Party(Long game, String name, String description, LocalDateTime partyAt, boolean isPublic, int minimum,
+    public Party(Long game, String name, String description, LocalDateTime partyAt, boolean publicFlag, int minimum,
                  int maximum) {
         this.game = game;
         this.name = name;
         this.description = description != null ? description : "";
         this.partyAt = partyAt;
-        this.isPublic = isPublic;
+        this.publicFlag = publicFlag;
         this.hit = 0;
         this.minimum = minimum;
         this.maximum = maximum;
+        this.total = 0;
         this.partyStatus = PartyStatus.PENDING;
     }
 
     public void addPartyMember(PartyMember partyMember) {
         this.partyMembers.add(partyMember);
         partyMember.setParty(this);
+        this.total += 1;
+    }
+
+    public void deletePartyMember(PartyMember partyMember) {
+        this.partyMembers.remove(partyMember);
+        partyMember.setParty(null);
+        this.total -= 1;
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
@@ -59,6 +59,9 @@ public class Party {
     @Column(nullable = false)
     private LocalDateTime partyAt;
 
+    @Column
+    private LocalDateTime endedAt;
+
     @Column(name = "is_public", nullable = false)
     private boolean publicFlag;
 
@@ -119,5 +122,9 @@ public class Party {
         this.partyMembers.remove(partyMember);
         partyMember.setParty(null);
         this.total -= 1;
+    }
+
+    public void closeParTy() {
+        this.endedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/entity/PartyMember.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/PartyMember.java
@@ -20,7 +20,8 @@ import lombok.*;
 @Table(
         name = "party_member",
         indexes = {
-                @Index(name = "idx_party_member_party_id_role", columnList = "party_id, partyRole")
+                @Index(name = "idx_party_member_party_id_role", columnList = "party_id, party_role"),
+                @Index(name = "idx_party_member_member_id", columnList = "member_id")
         }
 )
 @Getter
@@ -62,8 +63,7 @@ public class PartyMember extends BaseTime {
 
     public void delete() {
         if (this.party != null) {
-            this.party.getPartyMembers().remove(this);
-            this.party = null;
+            this.party.deletePartyMember(this);
         }
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/mapper/PartyMapper.java
+++ b/src/main/java/com/ll/playon/domain/party/party/mapper/PartyMapper.java
@@ -11,7 +11,7 @@ public class PartyMapper {
                 .name(postPartyRequest.name())
                 .description(postPartyRequest.description())
                 .partyAt(postPartyRequest.partyAt())
-                .isPublic(postPartyRequest.isPublic())
+                .publicFlag(postPartyRequest.isPublic())
                 .minimum(postPartyRequest.minimum())
                 .maximum(postPartyRequest.maximum())
                 .build();

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -155,4 +155,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
 
     List<Party> findAllByPartyStatusAndPublicFlagTrueOrderByPartyAtAscCreatedAtDesc(PartyStatus partyStatus,
                                                                                     Pageable pageable);
+
+    List<Party> findAllByPartyStatusAndPublicFlagTrueOrderByPartyAtDescCreatedAtDesc(PartyStatus partyStatus,
+                                                                                    Pageable pageable);
 }

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -152,4 +152,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
 
     @Query("SELECT p FROM Party p WHERE p.game = :gameId")
     Page<Party> findByGameId(@Param("gameId") Long gameId, Pageable partyPageable);
+
+    List<Party> findAllByPartyStatusAndPublicFlagTrueOrderByPartyAtAscCreatedAtDesc(PartyStatus partyStatus,
+                                                                                    Pageable pageable);
 }

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -148,8 +148,6 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             """)
     List<PartyMember> findPartyMembersByPartyIds(@Param("partyIds") List<Long> partyIds);
 
-    List<Party> findAllByPartyStatusOrderByPartyAtDescCreatedAtDesc(PartyStatus partyStatus, Pageable pageable);
-
     @Query("SELECT p FROM Party p WHERE p.game = :gameId")
     Page<Party> findByGameId(@Param("gameId") Long gameId, Pageable partyPageable);
 

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -123,12 +123,35 @@ public class PartyService {
         );
     }
 
-    // 파티 메인 조회 (limit 만큼)
-    public GetPartyMainResponse getPartyMain(int limit) {
+    // 메인용 진행 예정 파티 조회 (limit 만큼)
+    public GetPartyMainResponse getPendingPartyMain(int limit) {
         Pageable pageable = PageRequest.of(0, limit);
 
         List<Party> parties = this.partyRepository.findAllByPartyStatusAndPublicFlagTrueOrderByPartyAtAscCreatedAtDesc(
                 PartyStatus.PENDING,
+                pageable);
+
+        if (parties.isEmpty()) {
+            return new GetPartyMainResponse(Collections.emptyList());
+        }
+
+        List<Long> partyIds = parties.stream().map(Party::getId).toList();
+
+        return new GetPartyMainResponse(
+                this.mergePartyWithJoinData(
+                        parties,
+                        this.partyRepository.findPartyTagsByPartyIds(partyIds),
+                        this.partyRepository.findPartyMembersByPartyIds(partyIds)
+                )
+        );
+    }
+
+    // 메인용 종료된 파티 조회 (limit 만큼)
+    public GetPartyMainResponse getCompletedPartyMain(int limit) {
+        Pageable pageable = PageRequest.of(0, limit);
+
+        List<Party> parties = this.partyRepository.findAllByPartyStatusAndPublicFlagTrueOrderByPartyAtDescCreatedAtDesc(
+                PartyStatus.COMPLETED,
                 pageable);
 
         if (parties.isEmpty()) {

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -212,6 +212,7 @@ public class PartyService {
         );
     }
 
+    // TODO: 동시성 고려
     // 파티 상세 정보 조회
     @Transactional
     public GetPartyDetailResponse getPartyDetail(long partyId) {

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -127,8 +127,8 @@ public class PartyService {
     public GetPartyMainResponse getPartyMain(int limit) {
         Pageable pageable = PageRequest.of(0, limit);
 
-        List<Party> parties = this.partyRepository.findAllByPartyStatusOrderByPartyAtDescCreatedAtDesc(
-                PartyStatus.COMPLETED,
+        List<Party> parties = this.partyRepository.findAllByPartyStatusAndPublicFlagTrueOrderByPartyAtAscCreatedAtDesc(
+                PartyStatus.PENDING,
                 pageable);
 
         if (parties.isEmpty()) {

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -241,8 +241,7 @@ public class PartyService {
         Party party = PartyContext.getParty();
 
         // TODO: 유니크 제약 조건 있으면 체크
-
-        this.updatePartyFromRequest(party, putPartyRequest);
+        party.update(putPartyRequest);
 
         this.partyTagService.updatePartyTags(party, putPartyRequest.tags());
 
@@ -388,17 +387,6 @@ public class PartyService {
         return request.tags().stream()
                 .map(tag -> PartyTagMapper.build(party, tag.type(), tag.value()))
                 .toList();
-    }
-
-    // 파티 정보 수정
-    private void updatePartyFromRequest(Party party, PutPartyRequest request) {
-        party.setName(request.name());
-        party.setDescription(request.description() != null ? request.description() : "");
-        party.setPartyAt(request.partyAt());
-        party.setPublicFlag(request.isPublic());
-        party.setMinimum(request.minimum());
-        party.setMaximum(request.maximum());
-        party.setGame(request.game());
     }
 
     // Party 내부 Join 데이터들 병합

--- a/src/main/java/com/ll/playon/domain/party/party/util/PartySortUtils.java
+++ b/src/main/java/com/ll/playon/domain/party/party/util/PartySortUtils.java
@@ -7,10 +7,12 @@ import org.springframework.data.domain.Sort.Direction;
 public class PartySortUtils {
     private static final Map<String, Sort> SORT_MAP = Map.of(
             "latest", Sort.by(Direction.DESC, "createdAt"),
-            "popular", Sort.by(Direction.DESC, "hit")
+            "popular", Sort.by(Direction.DESC, "hit"),
+            "partyAt", Sort.by(Direction.ASC, "partyAt"),
+            "personal", Sort.by(Direction.DESC, "total")
     );
 
     public static Sort getSort(String orderBy) {
-        return SORT_MAP.getOrDefault(orderBy, SORT_MAP.get("latest"));
+        return SORT_MAP.getOrDefault(orderBy, SORT_MAP.get("latest")).and(Sort.by(Direction.DESC, "createdAt"));
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/validation/PartyMemberValidation.java
+++ b/src/main/java/com/ll/playon/domain/party/party/validation/PartyMemberValidation.java
@@ -25,7 +25,7 @@ public class PartyMemberValidation {
     // 파티멤버가 맞는지 확인
     public static void checkPartyMember(Party party, PartyMember partyMember) {
         if (!party.getPartyMembers().contains(partyMember)) {
-            ErrorCode.PARTY_MEMBER_NOT_FOUND.throwServiceException();
+            ErrorCode.IS_NOT_PARTY_MEMBER.throwServiceException();
         }
     }
 

--- a/src/main/java/com/ll/playon/domain/party/party/validation/PartyMemberValidation.java
+++ b/src/main/java/com/ll/playon/domain/party/party/validation/PartyMemberValidation.java
@@ -1,6 +1,7 @@
 package com.ll.playon.domain.party.party.validation;
 
 import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.party.party.entity.Party;
 import com.ll.playon.domain.party.party.entity.PartyMember;
 import com.ll.playon.domain.party.party.type.PartyRole;
 import com.ll.playon.global.exceptions.ErrorCode;
@@ -18,6 +19,13 @@ public class PartyMemberValidation {
     public static void checkIsNotPartyMemberOwn(PartyMember partyMember, Member actor) {
         if (!partyMember.isOwn(actor)) {
             ErrorCode.IS_NOT_PARTY_MEMBER_OWN.throwServiceException();
+        }
+    }
+
+    // 파티멤버가 맞는지 확인
+    public static void checkPartyMember(Party party, PartyMember partyMember) {
+        if (!party.getPartyMembers().contains(partyMember)) {
+            ErrorCode.PARTY_MEMBER_NOT_FOUND.throwServiceException();
         }
     }
 

--- a/src/main/java/com/ll/playon/domain/party/party/validation/PartyValidation.java
+++ b/src/main/java/com/ll/playon/domain/party/party/validation/PartyValidation.java
@@ -1,0 +1,14 @@
+package com.ll.playon.domain.party.party.validation;
+
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.party.type.PartyStatus;
+import com.ll.playon.global.exceptions.ErrorCode;
+
+public class PartyValidation {
+    // 파티가 끝났는지 확인
+    public static void checkIsPartyClosed(Party party) {
+        if (!party.getPartyStatus().equals(PartyStatus.COMPLETED)) {
+            ErrorCode.PARTY_IS_NOT_ENDED.throwServiceException();
+        }
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/partyLog/controller/PartyLogController.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/controller/PartyLogController.java
@@ -3,6 +3,7 @@ package com.ll.playon.domain.party.partyLog.controller;
 import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.party.partyLog.dto.request.PostPartyLogRequest;
 import com.ll.playon.domain.party.partyLog.dto.request.PutPartyLogRequest;
+import com.ll.playon.domain.party.partyLog.dto.response.GetAllPartyLogResponse;
 import com.ll.playon.domain.party.partyLog.dto.response.PartyLogResponse;
 import com.ll.playon.domain.party.partyLog.service.PartyLogService;
 import com.ll.playon.global.response.RsData;
@@ -13,6 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -49,6 +51,15 @@ public class PartyLogController {
         Member actor = this.userContext.findById(5L);
 
         this.partyLogService.saveImageUrl(actor, partyId, logId, url);
+    }
+
+    @GetMapping("/party/{partyId}")
+    @Operation(summary = "파티의 모든 파티 로그 조회")
+    public RsData<GetAllPartyLogResponse> getAllPartyLogs(@PathVariable long partyId) {
+        // TODO : 추후 롤백
+//        Member actor = this.userContext.getActor();
+
+        return RsData.success(HttpStatus.OK, this.partyLogService.getAllPartyLogs(partyId));
     }
 
     @PutMapping("/{logId}/party/{partyId}")

--- a/src/main/java/com/ll/playon/domain/party/partyLog/dto/request/PostPartyLogRequest.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/dto/request/PostPartyLogRequest.java
@@ -1,6 +1,5 @@
 package com.ll.playon.domain.party.partyLog.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.Objects;
 
@@ -11,7 +10,6 @@ public record PostPartyLogRequest(
         @NotNull
         String content,
 
-        @NotBlank
         String fileType,
 
         Long partyMemberId

--- a/src/main/java/com/ll/playon/domain/party/partyLog/dto/response/GetAllPartyLogResponse.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/dto/response/GetAllPartyLogResponse.java
@@ -1,0 +1,8 @@
+package com.ll.playon.domain.party.partyLog.dto.response;
+
+import java.util.List;
+
+public record GetAllPartyLogResponse(
+        List<GetPartyLogResponse> partyLogs
+) {
+}

--- a/src/main/java/com/ll/playon/domain/party/partyLog/dto/response/GetPartyLogResponse.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/dto/response/GetPartyLogResponse.java
@@ -1,0 +1,30 @@
+package com.ll.playon.domain.party.partyLog.dto.response;
+
+import com.ll.playon.domain.party.partyLog.entity.PartyLog;
+import lombok.NonNull;
+
+public record GetPartyLogResponse(
+        @NonNull
+        String nickname,
+
+        @NonNull
+        String profileImageUrl,
+
+        @NonNull
+        String comment,
+
+        @NonNull
+        String content,
+
+        String screenShotUrl
+) {
+    public GetPartyLogResponse(PartyLog partyLog, String screenShotUrl) {
+        this(
+                partyLog.getPartyMember().getMember().getNickname(),
+                partyLog.getPartyMember().getMember().getProfileImg(),
+                partyLog.getComment(),
+                partyLog.getContent(),
+                screenShotUrl
+        );
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/partyLog/entity/PartyLog.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/entity/PartyLog.java
@@ -1,6 +1,7 @@
 package com.ll.playon.domain.party.partyLog.entity;
 
 import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.domain.party.partyLog.dto.request.PutPartyLogRequest;
 import com.ll.playon.global.jpa.entity.BaseTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -36,5 +37,10 @@ public class PartyLog extends BaseTime {
     public void delete() {
         this.partyMember.setPartyLog(null);
         this.partyMember = null;
+    }
+
+    public void update(PutPartyLogRequest request) {
+        this.comment = request.comment();
+        this.content = request.content();
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/partyLog/service/PartyLogService.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/service/PartyLogService.java
@@ -118,8 +118,7 @@ public class PartyLogService {
         PartyMemberValidation.checkIsNotPartyMemberOwn(partyMember, actor);
 
         PartyLog partyLog = this.getPartyLog(logId);
-
-        this.updatePartyLog(partyLog, request);
+        partyLog.update(request);
 
         this.imageService.deleteImagesByIdAndUrl(ImageType.LOG, logId, request.deleteUrl());
 
@@ -149,11 +148,5 @@ public class PartyLogService {
     private PartyLog getPartyLog(long logId) {
         return this.partyLogRepository.findById(logId)
                 .orElseThrow(ErrorCode.PARTY_LOG_NOT_FOUND::throwServiceException);
-    }
-
-    // PartyLog 수정
-    private void updatePartyLog(PartyLog partyLog, PutPartyLogRequest request) {
-        partyLog.setComment(request.comment());
-        partyLog.setContent(request.content());
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/partyLog/service/PartyLogService.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/service/PartyLogService.java
@@ -8,9 +8,12 @@ import com.ll.playon.domain.party.party.context.PartyMemberContext;
 import com.ll.playon.domain.party.party.entity.Party;
 import com.ll.playon.domain.party.party.entity.PartyMember;
 import com.ll.playon.domain.party.party.repository.PartyMemberRepository;
+import com.ll.playon.domain.party.party.repository.PartyRepository;
 import com.ll.playon.domain.party.party.validation.PartyMemberValidation;
 import com.ll.playon.domain.party.partyLog.dto.request.PostPartyLogRequest;
 import com.ll.playon.domain.party.partyLog.dto.request.PutPartyLogRequest;
+import com.ll.playon.domain.party.partyLog.dto.response.GetAllPartyLogResponse;
+import com.ll.playon.domain.party.partyLog.dto.response.GetPartyLogResponse;
 import com.ll.playon.domain.party.partyLog.dto.response.PartyLogResponse;
 import com.ll.playon.domain.party.partyLog.entity.PartyLog;
 import com.ll.playon.domain.party.partyLog.event.ImageDeleteEvent;
@@ -21,6 +24,8 @@ import com.ll.playon.global.annotation.ActivePartyMemberOnly;
 import com.ll.playon.global.aws.s3.S3Service;
 import com.ll.playon.global.exceptions.ErrorCode;
 import java.net.URL;
+import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -31,6 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PartyLogService {
     private final ImageService imageService;
     private final S3Service s3Service;
+    private final PartyRepository partyRepository;
     private final PartyLogRepository partyLogRepository;
     private final PartyMemberRepository partyMemberRepository;
     private final ApplicationEventPublisher eventPublisher;
@@ -64,7 +70,7 @@ public class PartyLogService {
 
     // 로그 이미지 저장
     private URL savePartyLogImage(long logId, String fileType) {
-        return this.s3Service.generatePresignedUrl(ImageType.LOG, logId, fileType);
+        return fileType != null ? this.s3Service.generatePresignedUrl(ImageType.LOG, logId, fileType) : null;
     }
 
     // 스크린샷 URL 저장
@@ -72,12 +78,32 @@ public class PartyLogService {
     @ActivePartyMemberOnly
     @Transactional
     public void saveImageUrl(Member actor, long partyId, long logId, String url) {
+        if (url == null) {
+            return;
+        }
+
         Party party = PartyContext.getParty();
 
         PartyMemberValidation.checkIsNotPartyMemberOwn(PartyMemberContext.getPartyMember(), actor);
         PartyLogValidation.checkIsPartyEnd(party);
 
         this.imageService.saveImage(ImageType.LOG, logId, url);
+    }
+
+    // 파티의 모든 파티 로그 조회
+    public GetAllPartyLogResponse getAllPartyLogs(long partyId) {
+        Party party = this.partyRepository.findById(partyId)
+                .orElseThrow(ErrorCode.PARTY_NOT_FOUND::throwServiceException);
+
+        List<PartyMember> partyMembers = party.getPartyMembers();
+
+        return new GetAllPartyLogResponse(partyMembers.stream()
+                .map(PartyMember::getPartyLog)
+                .filter(Objects::nonNull)
+                .map(partyLog -> new GetPartyLogResponse(partyLog,
+                        this.imageService.getImageById(ImageType.LOG, partyLog.getId()))
+                )
+                .toList());
     }
 
     // 파티 로그 수정

--- a/src/main/java/com/ll/playon/domain/party/partyLog/service/PartyLogService.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/service/PartyLogService.java
@@ -59,6 +59,8 @@ public class PartyLogService {
             PartyMember mvpCandidate = this.partyMemberRepository.findById(request.partyMemberId())
                     .orElseThrow(ErrorCode.PARTY_MEMBER_NOT_FOUND::throwServiceException);
 
+            PartyMemberValidation.checkPartyMember(party, partyMember);
+
             mvpCandidate.voteMvp();
         }
 

--- a/src/main/java/com/ll/playon/global/aspect/ActivePartyMemberCheckAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/ActivePartyMemberCheckAspect.java
@@ -51,6 +51,7 @@ public class ActivePartyMemberCheckAspect {
         }
     }
 
+    // 활성화된 파티 멤버인지 확인
     private boolean isNotActivePartyMember(Member actor, Party party) {
         return party.getPartyMembers().stream()
                 .noneMatch(pm -> pm.getMember().getId().equals(actor.getId())

--- a/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
@@ -26,6 +26,9 @@ public enum ErrorCode {
     S3_OBJECT_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 오브젝트 제거에 실패하였습니다."),
     S3_OBJECT_GET_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 오브젝트 호출에 실패하였습니다."),
 
+    // 이미지
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."),
+
     // Filtering
     PAGE_SIZE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "pageSize는 1에서 100 사이로 입력해주세요."),
 

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -12,9 +12,22 @@ import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.member.entity.enums.Role;
 import com.ll.playon.domain.member.repository.MemberRepository;
 import com.ll.playon.domain.member.service.MemberService;
+import com.ll.playon.domain.party.party.dto.request.PartyTagRequest;
+import com.ll.playon.domain.party.party.dto.request.PostPartyRequest;
+import com.ll.playon.domain.party.party.repository.PartyRepository;
+import com.ll.playon.domain.party.party.service.PartyService;
 import com.ll.playon.global.type.TagType;
 import com.ll.playon.global.type.TagValue;
 import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationRunner;
@@ -22,10 +35,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.time.LocalDateTime;
-import java.util.*;
-import java.util.stream.Collectors;
 
 @Configuration
 @RequiredArgsConstructor
@@ -35,6 +44,8 @@ public class BaseInitData {
     private final GuildRepository guildRepository;
     private final GuildMemberRepository guildMemberRepository;
     private final MemberService memberService;
+    private final PartyService partyService;
+    private final PartyRepository partyRepository;
     private final PasswordEncoder passwordEncoder;
     private final GameRepository gameRepository;
 
@@ -47,6 +58,7 @@ public class BaseInitData {
         return args -> {
             self.makeSampleUsers();
             self.makeSampleGuilds();
+            self.makeSampleParties();
         };
     }
 
@@ -57,7 +69,8 @@ public class BaseInitData {
         }
 
         Member sampleMember1 = Member.builder()
-                .steamId(123L).username("sampleUser1").nickname("sampleUser1").lastLoginAt(LocalDateTime.now()).role(Role.USER).build();
+                .steamId(123L).username("sampleUser1").nickname("sampleUser1").lastLoginAt(LocalDateTime.now())
+                .role(Role.USER).build();
         memberRepository.save(sampleMember1);
         List<Long> gameAppIds = Arrays.asList(730L, 570L);
         memberService.saveUserGameList(gameAppIds, sampleMember1);
@@ -89,15 +102,55 @@ public class BaseInitData {
         memberRepository.save(owner);
 
         memberService.saveUserGameList(gameAppIds, owner);
+
+        Member partyOwner = Member.builder()
+                .steamId(555L)
+                .username("partyOwner")
+                .nickname("partyOwner")
+                .profileImg("")
+                .lastLoginAt(LocalDateTime.now())
+                .role(Role.USER)
+                .build();
+        memberRepository.save(partyOwner);
+
+        memberService.saveUserGameList(gameAppIds, partyOwner);
+
+        Member partyOwner2 = Member.builder()
+                .steamId(556L)
+                .username("partyOwner2")
+                .nickname("partyOwner2")
+                .profileImg("")
+                .lastLoginAt(LocalDateTime.now())
+                .role(Role.USER)
+                .build();
+        memberRepository.save(partyOwner2);
+
+        memberService.saveUserGameList(gameAppIds, partyOwner2);
+
+        Member partyMember = Member.builder()
+                .steamId(2252L)
+                .username("partyMember")
+                .nickname("partyMember")
+                .profileImg("")
+                .lastLoginAt(LocalDateTime.now())
+                .role(Role.USER)
+                .build();
+        memberRepository.save(partyMember);
+
+        memberService.saveUserGameList(gameAppIds, partyMember);
     }
 
     @Transactional
     public void makeSampleGuilds() {
+<<<<<<< HEAD
         if (gameRepository.count() == 0) {
             return;
         }
 
         if(guildRepository.count() != 0) {
+=======
+        if (guildRepository.count() != 0) {
+>>>>>>> 8c1f356 ([REFACTOR] 파티 조회 조건 처리 및 인덱스 개선)
             return;
         }
 
@@ -165,7 +218,9 @@ public class BaseInitData {
             int added = 0;
 
             for (Member candidate : candidates) {
-                if (added >= memberCount) break;
+                if (added >= memberCount) {
+                    break;
+                }
 
                 // 이미 같은 길드에 들어간 멤버는 패스
                 GuildMember guildMember = GuildMember.builder()
@@ -179,15 +234,99 @@ public class BaseInitData {
         }
     }
 
+    @Transactional
+    public void makeSampleParties() {
+        if (this.partyRepository.count() != 0) {
+            return;
+        }
+
+        // 모든 멤버를 가져옵니다.
+        List<Member> members = memberRepository.findAll().stream()
+                .skip(Math.max(0, this.memberRepository.findAll().size() - 4))  // 뒤에서 4명 가져오기
+                .toList();
+
+        // 태그 타입과 태그 값들
+        List<TagType> tagTypes = new ArrayList<>(List.of(TagType.values()));
+
+        // 각 멤버에 대해 3개의 파티 생성
+        for (Member member : members) {
+            for (int i = 0; i < 3; i++) {
+                // 랜덤 값 생성
+                String randomName = "파티_" + UUID.randomUUID().toString().substring(0, 6);  // 랜덤 이름 생성
+                String randomDescription = "랜덤 파티 설명 " + UUID.randomUUID().toString().substring(0, 6);  // 랜덤 설명
+                LocalDateTime randomPartyAt = LocalDateTime.now().plusDays(new Random().nextInt(30));  // 30일 이내의 랜덤 날짜
+                boolean isPublic = new Random().nextBoolean();  // 공개 여부 랜덤
+                int minimum = new Random().nextInt(2, 10);  // 최소 인원 2명 이상
+                int maximum = new Random().nextInt(10, 51);  // 최대 인원 10명 이상, 50명 이하
+                Long gameId = (long) (new Random().nextInt(1, 10));  // 랜덤 게임 ID (나중에 게임 엔티티로 연결)
+
+                // 파티 태그 생성
+                List<PartyTagRequest> randomTags = new ArrayList<>();
+
+                // 각 TagType에 대해 하나씩 TagValue를 선택하여 추가
+                for (TagType tagType : tagTypes) {
+                    // 해당 TagType에 맞는 TagValue들을 필터링
+                    List<TagValue> tagValuesForType = Arrays.stream(TagValue.values())
+                            .filter(tv -> isValidTagValueForType(tv, tagType))
+                            .toList();
+
+                    // TagType에 맞는 TagValue를 랜덤으로 1개 선택
+                    TagValue randomTagValue = tagValuesForType.get(new Random().nextInt(tagValuesForType.size()));
+
+                    // PartyTagRequest 생성 후 randomTags에 추가
+                    randomTags.add(new PartyTagRequest(tagType.getKoreanValue(), randomTagValue.getKoreanValue()));
+                }
+
+                // PostPartyRequest 객체 생성
+                PostPartyRequest postPartyRequest = new PostPartyRequest(
+                        randomName,
+                        randomDescription,
+                        randomPartyAt,
+                        isPublic,
+                        minimum,
+                        maximum,
+                        gameId,
+                        randomTags
+                );
+
+                // 파티 생성
+                this.partyService.createParty(member, postPartyRequest);
+            }
+        }
+    }
+
+    // 특정 TagValue가 TagType에 맞는 값인지 확인하는 메서드
+    private boolean isValidTagValueForType(TagValue tagValue, TagType tagType) {
+        switch (tagType) {
+            case PARTY_STYLE:
+                return tagValue == TagValue.HARDCORE || tagValue == TagValue.CASUAL || tagValue == TagValue.SPEEDRUN
+                       || tagValue == TagValue.COMPLETIONIST;
+            case GAME_SKILL:
+                return tagValue == TagValue.ROTTEN_WATER || tagValue == TagValue.STAGNANT_WATER
+                       || tagValue == TagValue.MUD_WATER || tagValue == TagValue.CLEAN_WATER
+                       || tagValue == TagValue.NEWBIE;
+            case GENDER:
+                return tagValue == TagValue.MALE || tagValue == TagValue.FEMALE;
+            case SOCIALIZING:
+                return tagValue == TagValue.SOCIAL_FRIENDLY || tagValue == TagValue.GAME_ONLY
+                       || tagValue == TagValue.NO_CHAT;
+            default:
+                return false;
+        }
+    }
+
     private List<GuildTag> createSampleGuildTags(Guild guild) {
         List<GuildTag> guildTags = new ArrayList<>();
         Random random = new Random();
 
         Map<TagType, List<TagValue>> tagTypeToValues = Map.of(
-                TagType.PARTY_STYLE, List.of(TagValue.HARDCORE, TagValue.CASUAL, TagValue.SPEEDRUN, TagValue.COMPLETIONIST),
-                TagType.GAME_SKILL, List.of(TagValue.ROTTEN_WATER, TagValue.STAGNANT_WATER, TagValue.MUD_WATER, TagValue.CLEAN_WATER, TagValue.NEWBIE),
+                TagType.PARTY_STYLE,
+                List.of(TagValue.HARDCORE, TagValue.CASUAL, TagValue.SPEEDRUN, TagValue.COMPLETIONIST),
+                TagType.GAME_SKILL,
+                List.of(TagValue.ROTTEN_WATER, TagValue.STAGNANT_WATER, TagValue.MUD_WATER, TagValue.CLEAN_WATER,
+                        TagValue.NEWBIE),
                 TagType.GENDER, List.of(TagValue.MALE, TagValue.FEMALE),
-                TagType.SOCIALIZING, List.of(TagValue.SOCIAL_FRIENDLY, TagValue.GAME_ONLY, TagValue.NOC_CHAT)
+                TagType.SOCIALIZING, List.of(TagValue.SOCIAL_FRIENDLY, TagValue.GAME_ONLY, TagValue.NO_CHAT)
         );
 
         for (TagType tagType : tagTypeToValues.keySet()) {

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -142,7 +142,11 @@ public class BaseInitData {
 
     @Transactional
     public void makeSampleGuilds() {
-        if (guildRepository.count() != 0) {
+        if (gameRepository.count() == 0) {
+            return;
+        }
+
+        if(guildRepository.count() != 0) {
             return;
         }
 

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -289,22 +289,17 @@ public class BaseInitData {
 
     // 특정 TagValue가 TagType에 맞는 값인지 확인하는 메서드
     private boolean isValidTagValueForType(TagValue tagValue, TagType tagType) {
-        switch (tagType) {
-            case PARTY_STYLE:
-                return tagValue == TagValue.HARDCORE || tagValue == TagValue.CASUAL || tagValue == TagValue.SPEEDRUN
-                       || tagValue == TagValue.COMPLETIONIST;
-            case GAME_SKILL:
-                return tagValue == TagValue.ROTTEN_WATER || tagValue == TagValue.STAGNANT_WATER
-                       || tagValue == TagValue.MUD_WATER || tagValue == TagValue.CLEAN_WATER
-                       || tagValue == TagValue.NEWBIE;
-            case GENDER:
-                return tagValue == TagValue.MALE || tagValue == TagValue.FEMALE;
-            case SOCIALIZING:
-                return tagValue == TagValue.SOCIAL_FRIENDLY || tagValue == TagValue.GAME_ONLY
-                       || tagValue == TagValue.NO_CHAT;
-            default:
-                return false;
-        }
+        return switch (tagType) {
+            case PARTY_STYLE ->
+                    tagValue == TagValue.HARDCORE || tagValue == TagValue.CASUAL || tagValue == TagValue.SPEEDRUN
+                    || tagValue == TagValue.COMPLETIONIST;
+            case GAME_SKILL -> tagValue == TagValue.ROTTEN_WATER || tagValue == TagValue.STAGNANT_WATER
+                               || tagValue == TagValue.MUD_WATER || tagValue == TagValue.CLEAN_WATER
+                               || tagValue == TagValue.NEWBIE;
+            case GENDER -> tagValue == TagValue.MALE || tagValue == TagValue.FEMALE;
+            case SOCIALIZING -> tagValue == TagValue.SOCIAL_FRIENDLY || tagValue == TagValue.GAME_ONLY
+                                || tagValue == TagValue.NO_CHAT;
+        };
     }
 
     private List<GuildTag> createSampleGuildTags(Guild guild) {

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -142,15 +142,7 @@ public class BaseInitData {
 
     @Transactional
     public void makeSampleGuilds() {
-<<<<<<< HEAD
-        if (gameRepository.count() == 0) {
-            return;
-        }
-
-        if(guildRepository.count() != 0) {
-=======
         if (guildRepository.count() != 0) {
->>>>>>> 8c1f356 ([REFACTOR] 파티 조회 조건 처리 및 인덱스 개선)
             return;
         }
 

--- a/src/main/java/com/ll/playon/global/type/TagValue.java
+++ b/src/main/java/com/ll/playon/global/type/TagValue.java
@@ -30,8 +30,7 @@ public enum TagValue {
     // 친목
     SOCIAL_FRIENDLY("친목 환영"),
     GAME_ONLY("게임만 하고 싶어요"),
-    NOC_CHAT("대화 안함");
-
+    NO_CHAT("대화 안함");
 
     private final String koreanValue;
 

--- a/src/main/java/com/ll/playon/standard/time/dto/TotalPlayTimeDto.java
+++ b/src/main/java/com/ll/playon/standard/time/dto/TotalPlayTimeDto.java
@@ -1,0 +1,10 @@
+package com.ll.playon.standard.time.dto;
+
+public record TotalPlayTimeDto(
+        long hour,
+
+        long minute,
+
+        long second
+) {
+}

--- a/src/main/java/com/ll/playon/standard/util/Ut.java
+++ b/src/main/java/com/ll/playon/standard/util/Ut.java
@@ -3,15 +3,17 @@ package com.ll.playon.standard.util;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ll.playon.global.app.AppConfig;
+import com.ll.playon.standard.time.dto.TotalPlayTimeDto;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.Map;
+import javax.crypto.SecretKey;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.crypto.SecretKey;
-import java.io.Serializable;
-import java.util.Map;
-import java.util.Date;
 
 @Slf4j
 public class Ut {
@@ -25,7 +27,8 @@ public class Ut {
 
         @SneakyThrows
         public static Map<String, Object> toMap(String jsonStr) {
-            return om.readValue(jsonStr, new TypeReference<Map<String, Object>>() {});
+            return om.readValue(jsonStr, new TypeReference<Map<String, Object>>() {
+            });
         }
     }
 
@@ -47,7 +50,7 @@ public class Ut {
         public static Map<String, Object> payload(String secret, String accessTokenStr) {
             SecretKey secretKey = Keys.hmacShaKeyFor(secret.getBytes());
 
-            try{
+            try {
                 return Jwts
                         .parserBuilder()
                         .setSigningKey(secretKey)
@@ -57,6 +60,18 @@ public class Ut {
             } catch (Exception e) {
                 return null;
             }
+        }
+    }
+
+    public static class Time {
+        public static TotalPlayTimeDto getTotalPlayTime(LocalDateTime startAt, LocalDateTime endAt) {
+            Duration duration = Duration.between(startAt, endAt);
+
+            return new TotalPlayTimeDto(
+                    duration.toHours(),
+                    duration.toMinutes() % 60,
+                    duration.toSeconds() % 60
+            );
         }
     }
 }

--- a/src/test/java/com/ll/playon/domain/game/controller/GameControllerTest.java
+++ b/src/test/java/com/ll/playon/domain/game/controller/GameControllerTest.java
@@ -1,5 +1,11 @@
 package com.ll.playon.domain.game.controller;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.ll.playon.domain.game.game.controller.GameController;
 import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.game.game.repository.GameRepository;
@@ -7,13 +13,16 @@ import com.ll.playon.domain.member.TestMemberHelper;
 import com.ll.playon.domain.party.party.entity.Party;
 import com.ll.playon.domain.party.party.entity.PartyMember;
 import com.ll.playon.domain.party.party.repository.PartyRepository;
+import com.ll.playon.domain.party.party.type.PartyRole;
 import com.ll.playon.domain.party.partyLog.entity.PartyLog;
 import com.ll.playon.domain.party.partyLog.repository.PartyLogRepository;
-import com.ll.playon.domain.party.party.type.PartyRole;
 import com.ll.playon.global.openFeign.SteamStoreClient;
 import com.ll.playon.global.openFeign.dto.GameItem;
 import com.ll.playon.global.openFeign.dto.SteamSearchResponse;
 import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,14 +34,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -171,7 +172,7 @@ public class GameControllerTest {
                 .game(game.getId())
                 .name("Test Party")
                 .partyAt(LocalDateTime.now().plusDays(1))
-                .isPublic(true)
+                .publicFlag(true)
                 .minimum(1)
                 .maximum(5)
                 .build());
@@ -196,7 +197,7 @@ public class GameControllerTest {
                 .game(game.getId())
                 .name("Logged Party")
                 .partyAt(LocalDateTime.now().minusDays(1))
-                .isPublic(true)
+                .publicFlag(true)
                 .minimum(1)
                 .maximum(4)
                 .build());


### PR DESCRIPTION
## 1. 조회 조건 처리
### 1. 로그아웃 상태일 경우
- 모든 공개 가능한 파티가 다 보여야 함.
- 파티 상태는 PENDING
- DB에서 가져올 때는 페이징된 값, 즉 pageSize 초과된 값들을 가져올 순 없음
- 정렬 기준은 Controller에서 넘겨주는 order By,
- 그 정보 매핑은 내가 이전에 준 PartySortUtil 클래스를 통해서 가능
- 정렬 1차 기준이 동일하다면, createdAt DESC를 기반으로 재진행
- 모든 정렬이 정렬 기준과 정확하게 진행. (SORT_MAP 의 정렬 기준 하나하나 검사)
- tagValue 리스트에 값이 없으면 전체 조회, 값이 있으면 모두 포함한 데이터 조회

### 2. 로그인 상태일 경우
- 1번의 내용을 동일하게 포함
- 단, 사용자의 파티가 존재할 경우, 공개여부와 상관없이 사용자의 파티들을 제일 앞에서 보여줘야 함
- 당연히 이것들도 페이징 처리에는 포함되어야 함. 파티 데이터가 11개, 나머지 데이터가 20개면
2페이지 1번까지는 파티 데이터, 그 이후부터 나머지 데이터. 이렇게 출력되도록

## 2. 메인용 진행 예정 파티 조회 조건 처리
- 기존 공개 여부를 포함하지 않던 부분 수정
- 가까운 일정이 먼저 나오도록 수정

## 3. 메인용 종료된 파티 조회 구현
- 메인용 종료된 파티 리스트 조회 (limit 개수 만큼)
- 로그 확인을 위한 파티 리스트

> `Postman` 을 통한 1차 조회 테스트 진행 완료

## 4. Party 엔티티 필드 추가
- 총원을 나타내는 `total` 필드 추가
- 정렬 시 현재 인원을 기준으로 정렬해야 하는 경우가 존재
- 이를 필드 없이 DB 상에서 계속 처리하는 것보다, 그냥 update 쿼리 하나를 추가하는 방식을 채택
- 이를 통해 `Sort` 를 현재 방식 그대로 가져갈 수 있음
  - 추가적인 DB 작업이 필요하지 않음
  - 성능적으로도 쿼리 조건을 추가하는 것보다 그냥 `PartyMember` 추가 및 삭제 시 `Update` , `Delete` 쿼리를 발생시키는 게 더 `Trade-Off` 상 낫다고 판단

## 5. IsPublic 필드명 변경
- 순수 JPA 사용을 위해 `isPublic` -> `publicFlag` 로 필드명 변경

## 6. 관련된 인덱스 처리
- 인덱스 필드 추가 및 인덱스 추가

## 7. Enum Value명 변경
- `NOC_CHAT` -> `NO_CHAT`

## 8. 임의 파티 생성 (BaseInitData)
- `Member` 4명 추가
- 각 `Member` 당 파티 3개씩 추가
- 모든 필드는 임의 값
  - 필수 조건들 반영
  - ex) `List<PartyTag>` 의 최소 값은 4, 모든 `TagType` 은 최소 1개씩 존재, 각 `TagType` 당 여러 개의 `TagValue` 가 생성될 수 있음

---
# 추가 작업
## 1. 파티 로그 조회
- 파티의 모든 파티 로그 조회

## 2. 파티 결과창 조회
- 파티의 결과창 조회
- 파티 로그 정보들과 파티 결과 정보들
- MVP point가 모두 0이거나 동점일 시
  - 파티장을 MVP로 선정
- 총 플레이 시간을 `TotalPlayTimeDto' 로 반환
  -  시간, 분, 초가 들어있음
  - 해당 `Dto` 구하는 `Util` 함수 구현
- 종료된 파티에 한정

## 3. 필요한 필드 추가
- `Party` 엔티티에 종료되는 시간인 `endedAt` 필드 추가
  - 종료되지 않을 시 `null`

## 4. 이미지 작업 수정
- 단일 이미지 호출 메서드 추가
- 이미지가 존재하지 않으면 "" 처럼 빈 문자열로 반환

## 5. 로그 작성 권한 체크 수정
- MVP 투표 대상이 파티원인지 확인

## 6. Update 방식 변경
- `set` 대신 엔티티 내부에서 변경 진행