### PR TITLE
[FEAT] 게임 상세 기능 구현

### DIFF
--- a/src/main/java/com/ll/playon/domain/game/game/controller/GameController.java
+++ b/src/main/java/com/ll/playon/domain/game/game/controller/GameController.java
@@ -1,5 +1,6 @@
 package com.ll.playon.domain.game.game.controller;
 
+import com.ll.playon.domain.game.game.dto.response.GameDetailWithPartyResponse;
 import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.game.game.dto.GameListResponse;
 import com.ll.playon.domain.game.game.service.GameService;
@@ -10,6 +11,8 @@ import com.ll.playon.global.steamAPI.SteamAPI;
 import com.ll.playon.global.security.UserContext;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,5 +48,14 @@ public class GameController {
     @GetMapping("/{appid}")
     public RsData<SteamGame> getGameDetail(@PathVariable Long appid) {
         return RsData.success(HttpStatus.OK,steamAPI.fetchOrCreateGameDetail(appid));
+    }
+
+    @GetMapping("/{appid}/details")
+    public RsData<GameDetailWithPartyResponse> getGameDetail(
+            @PathVariable Long appid,
+            @PageableDefault(size = 3) Pageable partyPageable,
+            @PageableDefault(size = 3) Pageable logPageable
+    ) {
+        return RsData.success(HttpStatus.OK, gameService.getGameDetailWithParties(appid, partyPageable, logPageable));
     }
 }

--- a/src/main/java/com/ll/playon/domain/game/game/controller/GameController.java
+++ b/src/main/java/com/ll/playon/domain/game/game/controller/GameController.java
@@ -1,6 +1,9 @@
 package com.ll.playon.domain.game.game.controller;
 
+import com.ll.playon.domain.game.game.dto.request.GameSearchCondition;
+import com.ll.playon.domain.game.game.dto.response.GameAutoCompleteResponse;
 import com.ll.playon.domain.game.game.dto.response.GameDetailWithPartyResponse;
+import com.ll.playon.domain.game.game.dto.response.GameSummaryResponse;
 import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.game.game.dto.GameListResponse;
 import com.ll.playon.domain.game.game.service.GameService;
@@ -9,6 +12,7 @@ import com.ll.playon.global.exceptions.ErrorCode;
 import com.ll.playon.global.response.RsData;
 import com.ll.playon.global.steamAPI.SteamAPI;
 import com.ll.playon.global.security.UserContext;
+import com.ll.playon.standard.page.dto.PageDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -58,4 +62,18 @@ public class GameController {
     ) {
         return RsData.success(HttpStatus.OK, gameService.getGameDetailWithParties(appid, partyPageable, logPageable));
     }
+
+    @GetMapping("/list")
+    public RsData<PageDto<GameSummaryResponse>> getFilteredGames(
+            @ModelAttribute GameSearchCondition condition,
+            @PageableDefault(size = 12) Pageable pageable
+    ) {
+        return RsData.success(HttpStatus.OK, gameService.searchGames(condition, pageable));
+    }
+
+    @GetMapping("/search")
+    public RsData<List<GameAutoCompleteResponse>> searchGameByKeyword(@RequestParam String keyword) {
+        return RsData.success(HttpStatus.OK, gameService.autoCompleteGames(keyword));
+    }
+
 }

--- a/src/main/java/com/ll/playon/domain/game/game/controller/GameController.java
+++ b/src/main/java/com/ll/playon/domain/game/game/controller/GameController.java
@@ -4,6 +4,7 @@ import com.ll.playon.domain.game.game.dto.request.GameSearchCondition;
 import com.ll.playon.domain.game.game.dto.response.GameAutoCompleteResponse;
 import com.ll.playon.domain.game.game.dto.response.GameDetailWithPartyResponse;
 import com.ll.playon.domain.game.game.dto.response.GameSummaryResponse;
+import com.ll.playon.domain.game.game.dto.response.PartySummaryResponse;
 import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.game.game.dto.GameListResponse;
 import com.ll.playon.domain.game.game.service.GameService;
@@ -74,6 +75,14 @@ public class GameController {
     @GetMapping("/search")
     public RsData<List<GameAutoCompleteResponse>> searchGameByKeyword(@RequestParam String keyword) {
         return RsData.success(HttpStatus.OK, gameService.autoCompleteGames(keyword));
+    }
+
+    @GetMapping("/{appid}/party")
+    public RsData<PageDto<PartySummaryResponse>> getGameParties(
+            @PathVariable Long appid,
+            @PageableDefault(size = 12, sort = "partyAt") Pageable pageable
+    ) {
+        return RsData.success(HttpStatus.OK, gameService.getGameParties(appid, pageable));
     }
 
 }

--- a/src/main/java/com/ll/playon/domain/game/game/controller/GameController.java
+++ b/src/main/java/com/ll/playon/domain/game/game/controller/GameController.java
@@ -1,10 +1,7 @@
 package com.ll.playon.domain.game.game.controller;
 
 import com.ll.playon.domain.game.game.dto.request.GameSearchCondition;
-import com.ll.playon.domain.game.game.dto.response.GameAutoCompleteResponse;
-import com.ll.playon.domain.game.game.dto.response.GameDetailWithPartyResponse;
-import com.ll.playon.domain.game.game.dto.response.GameSummaryResponse;
-import com.ll.playon.domain.game.game.dto.response.PartySummaryResponse;
+import com.ll.playon.domain.game.game.dto.response.*;
 import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.game.game.dto.GameListResponse;
 import com.ll.playon.domain.game.game.service.GameService;
@@ -16,7 +13,9 @@ import com.ll.playon.global.security.UserContext;
 import com.ll.playon.standard.page.dto.PageDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.ObjectUtils;
@@ -58,8 +57,8 @@ public class GameController {
     @GetMapping("/{appid}/details")
     public RsData<GameDetailWithPartyResponse> getGameDetail(
             @PathVariable Long appid,
-            @PageableDefault(size = 3) Pageable partyPageable,
-            @PageableDefault(size = 3) Pageable logPageable
+            @Qualifier("partyPage") @PageableDefault(size = 3) Pageable partyPageable,
+            @Qualifier("logPage") @PageableDefault(size = 3) Pageable logPageable
     ) {
         return RsData.success(HttpStatus.OK, gameService.getGameDetailWithParties(appid, partyPageable, logPageable));
     }
@@ -84,5 +83,14 @@ public class GameController {
     ) {
         return RsData.success(HttpStatus.OK, gameService.getGameParties(appid, pageable));
     }
+
+    @GetMapping("/{appid}/logs")
+    public RsData<PageDto<PartyLogSummaryResponse>> getGamePartyLogs(
+            @PathVariable Long appid,
+            @PageableDefault(size = 12, sort="createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return RsData.success(HttpStatus.OK, gameService.getGamePartyLogs(appid, pageable));
+    }
+
 
 }

--- a/src/main/java/com/ll/playon/domain/game/game/dto/request/GameSearchCondition.java
+++ b/src/main/java/com/ll/playon/domain/game/game/dto/request/GameSearchCondition.java
@@ -1,0 +1,18 @@
+package com.ll.playon.domain.game.game.dto.request;
+
+import com.ll.playon.domain.game.game.enums.PlayerType;
+import com.ll.playon.domain.game.game.enums.ReleaseStatus;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record GameSearchCondition(
+        String keyword,
+        Boolean isMacSupported,
+        LocalDate releasedAfter,
+        ReleaseStatus releaseStatus,
+        PlayerType playerType,
+        List<String> genres
+) {}

--- a/src/main/java/com/ll/playon/domain/game/game/dto/response/GameAutoCompleteResponse.java
+++ b/src/main/java/com/ll/playon/domain/game/game/dto/response/GameAutoCompleteResponse.java
@@ -1,0 +1,9 @@
+package com.ll.playon.domain.game.game.dto.response;
+
+import com.ll.playon.domain.game.game.entity.SteamGame;
+
+public record GameAutoCompleteResponse(Long appid, String name) {
+    public static GameAutoCompleteResponse from(SteamGame game) {
+        return new GameAutoCompleteResponse(game.getAppid(), game.getName());
+    }
+}

--- a/src/main/java/com/ll/playon/domain/game/game/dto/response/GameDetailResponse.java
+++ b/src/main/java/com/ll/playon/domain/game/game/dto/response/GameDetailResponse.java
@@ -1,0 +1,50 @@
+package com.ll.playon.domain.game.game.dto.response;
+
+import com.ll.playon.domain.game.game.entity.SteamGame;
+import com.ll.playon.domain.game.game.entity.SteamGenre;
+import com.ll.playon.domain.game.game.entity.SteamImage;
+import com.ll.playon.domain.game.game.entity.SteamMovie;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record GameDetailResponse(
+        Long appid,
+        String name,
+        String headerImage,
+        String shortDescription,
+        String aboutTheGame,
+        Integer requiredAge,
+        String website,
+        boolean isWindowsSupported,
+        boolean isMacSupported,
+        boolean isLinuxSupported,
+        LocalDate releaseDate,
+        String developers,
+        String publishers,
+        List<String> screenshots,
+        List<String> movies,
+        List<String> genres
+) {
+    public static GameDetailResponse from(SteamGame game) {
+        return new GameDetailResponse(
+                game.getAppid(),
+                game.getName(),
+                game.getHeaderImage(),
+                game.getShortDescription(),
+                game.getAboutTheGame(),
+                game.getRequiredAge(),
+                game.getWebsite(),
+                game.isWindowsSupported(),
+                game.isMacSupported(),
+                game.isLinuxSupported(),
+                game.getReleaseDate(),
+                game.getDevelopers(),
+                game.getPublishers(),
+                game.getScreenshots().stream().map(SteamImage::getScreenshot).toList(),
+                game.getMovies().stream().map(SteamMovie::getMovie).toList(),
+                game.getGenres().stream().map(SteamGenre::getName).toList()
+        );
+    }
+}
+

--- a/src/main/java/com/ll/playon/domain/game/game/dto/response/GameDetailWithPartyResponse.java
+++ b/src/main/java/com/ll/playon/domain/game/game/dto/response/GameDetailWithPartyResponse.java
@@ -1,0 +1,26 @@
+package com.ll.playon.domain.game.game.dto.response;
+
+import com.ll.playon.domain.game.game.entity.SteamGame;
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.partyLog.entity.PartyLog;
+
+import java.util.List;
+
+public record GameDetailWithPartyResponse(
+        GameDetailResponse game,
+        List<PartySummaryResponse> partyList,
+        List<PartyLogSummaryResponse> partyLogList
+) {
+    public static GameDetailWithPartyResponse from(
+            SteamGame game,
+            List<Party> parties,
+            List<PartyLog> partyLogs
+    ) {
+        return new GameDetailWithPartyResponse(
+                GameDetailResponse.from(game),
+                parties.stream().map(PartySummaryResponse::from).toList(),
+                partyLogs.stream().map(PartyLogSummaryResponse::from).toList()
+        );
+    }
+}
+

--- a/src/main/java/com/ll/playon/domain/game/game/dto/response/GameSummaryResponse.java
+++ b/src/main/java/com/ll/playon/domain/game/game/dto/response/GameSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.ll.playon.domain.game.game.dto.response;
+
+import com.ll.playon.domain.game.game.entity.SteamGame;
+import com.ll.playon.domain.game.game.entity.SteamGenre;
+
+import java.util.List;
+
+public record GameSummaryResponse(
+        Long appid,
+        String name,
+        String headerImage,
+        List<String> genres
+) {
+    public static GameSummaryResponse from(SteamGame game) {
+        return new GameSummaryResponse(
+                game.getAppid(),
+                game.getName(),
+                game.getHeaderImage(),
+                game.getGenres().stream()
+                        .map(SteamGenre::getName)
+                        .limit(2)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/ll/playon/domain/game/game/dto/response/PartyLogSummaryResponse.java
+++ b/src/main/java/com/ll/playon/domain/game/game/dto/response/PartyLogSummaryResponse.java
@@ -1,0 +1,28 @@
+package com.ll.playon.domain.game.game.dto.response;
+
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.partyLog.entity.PartyLog;
+
+import java.util.List;
+
+public record PartyLogSummaryResponse(
+        Long id,
+        Long partyId,
+        String name,
+        int memberCount,
+        List<String> tags
+) {
+    public static PartyLogSummaryResponse from(PartyLog log) {
+        Party party = log.getPartyMember().getParty();
+
+        return new PartyLogSummaryResponse(
+                log.getId(),
+                party.getId(),
+                party.getName(),
+                party.getPartyMembers().size(),
+                party.getPartyTags().stream()
+                        .map(tag -> tag.getValue().getKoreanValue())
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/ll/playon/domain/game/game/dto/response/PartySummaryResponse.java
+++ b/src/main/java/com/ll/playon/domain/game/game/dto/response/PartySummaryResponse.java
@@ -1,0 +1,26 @@
+package com.ll.playon.domain.game.game.dto.response;
+
+import com.ll.playon.domain.party.party.entity.Party;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PartySummaryResponse(
+        Long id,
+        String name,
+        LocalDateTime partyAt,
+        List<String> tags,
+        int memberCount
+) {
+    public static PartySummaryResponse from(Party party) {
+        return new PartySummaryResponse(
+                party.getId(),
+                party.getName(),
+                party.getPartyAt(),
+                party.getPartyTags().stream()
+                        .map(t -> t.getValue().getKoreanValue())
+                        .toList(),
+                party.getPartyMembers().size()
+        );
+    }
+}

--- a/src/main/java/com/ll/playon/domain/game/game/enums/PlayerType.java
+++ b/src/main/java/com/ll/playon/domain/game/game/enums/PlayerType.java
@@ -1,0 +1,14 @@
+package com.ll.playon.domain.game.game.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PlayerType {
+    SINGLE("싱글 플레이"),
+    MULTI("멀티 플레이");
+
+    private final String korean;
+}
+

--- a/src/main/java/com/ll/playon/domain/game/game/enums/ReleaseStatus.java
+++ b/src/main/java/com/ll/playon/domain/game/game/enums/ReleaseStatus.java
@@ -1,0 +1,14 @@
+package com.ll.playon.domain.game.game.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReleaseStatus {
+    RELEASED("발매"),
+    UNRELEASED("출시 예정");
+
+    private final String korean;
+}
+

--- a/src/main/java/com/ll/playon/domain/game/game/repository/GameRepository.java
+++ b/src/main/java/com/ll/playon/domain/game/game/repository/GameRepository.java
@@ -1,6 +1,9 @@
 package com.ll.playon.domain.game.game.repository;
 
+import com.ll.playon.domain.game.game.dto.request.GameSearchCondition;
 import com.ll.playon.domain.game.game.entity.SteamGame;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,4 +17,7 @@ public interface GameRepository extends JpaRepository<SteamGame, Long> {
     List<SteamGame> findTop5ByAppidIn(List<Long> appIds);
     Optional<SteamGame> findByAppid(Long appid);
     Optional<SteamGame> findSteamGameByAppid(Long appid);
+    List<SteamGame> searchByGameName(String keyword);
+    Page<SteamGame> searchGames(GameSearchCondition condition, Pageable pageable);
+
 }

--- a/src/main/java/com/ll/playon/domain/game/game/repository/GameRepository.java
+++ b/src/main/java/com/ll/playon/domain/game/game/repository/GameRepository.java
@@ -13,4 +13,5 @@ public interface GameRepository extends JpaRepository<SteamGame, Long> {
     List<SteamGame> findAllByAppidIn(List<Long> appIds);
     List<SteamGame> findTop5ByAppidIn(List<Long> appIds);
     Optional<SteamGame> findByAppid(Long appid);
+    Optional<SteamGame> findSteamGameByAppid(Long appid);
 }

--- a/src/main/java/com/ll/playon/domain/game/game/repository/GameRepositoryCustom.java
+++ b/src/main/java/com/ll/playon/domain/game/game/repository/GameRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.ll.playon.domain.game.game.repository;
+
+import com.ll.playon.domain.game.game.dto.request.GameSearchCondition;
+import com.ll.playon.domain.game.game.entity.SteamGame;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface GameRepositoryCustom {
+    Page<SteamGame> searchGames(GameSearchCondition condition, Pageable pageable);
+    List<SteamGame> searchByGameName(String keyword);
+}

--- a/src/main/java/com/ll/playon/domain/game/game/repository/GameRepositoryImpl.java
+++ b/src/main/java/com/ll/playon/domain/game/game/repository/GameRepositoryImpl.java
@@ -1,0 +1,102 @@
+package com.ll.playon.domain.game.game.repository;
+
+import com.ll.playon.domain.game.game.entity.QSteamGame;
+import com.ll.playon.domain.game.game.dto.request.GameSearchCondition;
+import com.ll.playon.domain.game.game.entity.*;
+import com.ll.playon.domain.game.game.enums.PlayerType;
+import com.ll.playon.domain.game.game.enums.ReleaseStatus;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class GameRepositoryImpl implements GameRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<SteamGame> searchByGameName(String keyword) {
+        QSteamGame game = QSteamGame.steamGame;
+
+        return queryFactory
+                .selectFrom(game)
+                .where(game.name.containsIgnoreCase(keyword))
+                .limit(5)
+                .fetch();
+    }
+
+    @Override
+    public Page<SteamGame> searchGames(GameSearchCondition condition, Pageable pageable) {
+        QSteamGame game = QSteamGame.steamGame;
+        QSteamGenre genre = QSteamGenre.steamGenre;
+
+        JPQLQuery<SteamGame> query = queryFactory
+                .selectFrom(game)
+                .leftJoin(game.genres, genre).fetchJoin()
+                .distinct()
+                .where(
+                        keywordContains(condition.keyword()),
+                        isMac(condition.isMacSupported()),
+                        releasedAfter(condition.releasedAfter()),
+                        releaseStatusEq(condition.releaseStatus()),
+                        genreIn(condition.genres()),
+                        playerTypeEq(condition.playerType())
+                );
+
+        long total = query.fetch().size();
+        List<SteamGame> content = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private BooleanExpression keywordContains(String keyword) {
+        return keyword != null && !keyword.isBlank()
+                ? QSteamGame.steamGame.name.containsIgnoreCase(keyword)
+                : null;
+    }
+
+    private BooleanExpression isMac(Boolean isMac) {
+        return isMac != null
+                ? QSteamGame.steamGame.isMacSupported.eq(isMac)
+                : null;
+    }
+
+    private BooleanExpression releasedAfter(LocalDate releasedAfter) {
+        return releasedAfter != null
+                ? QSteamGame.steamGame.releaseDate.goe(releasedAfter)
+                : null;
+    }
+
+    private BooleanExpression releaseStatusEq(ReleaseStatus status) {
+        if (status == null) return null;
+        return switch (status) {
+            case RELEASED -> QSteamGame.steamGame.releaseDate.loe(LocalDate.now());
+            case UNRELEASED -> QSteamGame.steamGame.releaseDate.gt(LocalDate.now());
+        };
+    }
+
+    private BooleanExpression genreIn(List<String> genres) {
+        return genres != null && !genres.isEmpty()
+                ? QSteamGenre.steamGenre.name.in(genres)
+                : null;
+    }
+
+    private BooleanExpression playerTypeEq(PlayerType type) {
+        if (type == null) return null;
+
+        return switch (type) {
+            case SINGLE -> QSteamGame.steamGame.isSinglePlayer.isTrue();
+            case MULTI -> QSteamGame.steamGame.isMultiPlayer.isTrue();
+        };
+    }
+}

--- a/src/main/java/com/ll/playon/domain/game/game/service/GameService.java
+++ b/src/main/java/com/ll/playon/domain/game/game/service/GameService.java
@@ -2,10 +2,7 @@ package com.ll.playon.domain.game.game.service;
 
 import com.ll.playon.domain.game.game.dto.GameListResponse;
 import com.ll.playon.domain.game.game.dto.request.GameSearchCondition;
-import com.ll.playon.domain.game.game.dto.response.GameAutoCompleteResponse;
-import com.ll.playon.domain.game.game.dto.response.GameDetailWithPartyResponse;
-import com.ll.playon.domain.game.game.dto.response.GameSummaryResponse;
-import com.ll.playon.domain.game.game.dto.response.PartySummaryResponse;
+import com.ll.playon.domain.game.game.dto.response.*;
 import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.game.game.entity.SteamGenre;
 import com.ll.playon.domain.game.game.repository.GameRepository;
@@ -152,6 +149,16 @@ public class GameService {
         Page<Party> page = partyRepository.findByGameId(game.getId(), pageable);
         return new PageDto<>(page.map(PartySummaryResponse::from));
     }
+
+    @Transactional(readOnly = true)
+    public PageDto<PartyLogSummaryResponse> getGamePartyLogs(Long appid, Pageable pageable) {
+        SteamGame game = gameRepository.findSteamGameByAppid(appid)
+                .orElseThrow(ErrorCode.GAME_NOT_FOUND::throwServiceException);
+
+        Page<PartyLog> page = partyLogRepository.findByPartyGameId(game.getId(), pageable);
+        return new PageDto<>(page.map(PartyLogSummaryResponse::from));
+    }
+
 
 
 }

--- a/src/main/java/com/ll/playon/domain/game/game/service/GameService.java
+++ b/src/main/java/com/ll/playon/domain/game/game/service/GameService.java
@@ -5,6 +5,7 @@ import com.ll.playon.domain.game.game.dto.request.GameSearchCondition;
 import com.ll.playon.domain.game.game.dto.response.GameAutoCompleteResponse;
 import com.ll.playon.domain.game.game.dto.response.GameDetailWithPartyResponse;
 import com.ll.playon.domain.game.game.dto.response.GameSummaryResponse;
+import com.ll.playon.domain.game.game.dto.response.PartySummaryResponse;
 import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.game.game.entity.SteamGenre;
 import com.ll.playon.domain.game.game.repository.GameRepository;
@@ -142,5 +143,15 @@ public class GameService {
                 .map(GameAutoCompleteResponse::from)
                 .toList();
     }
+
+    @Transactional(readOnly = true)
+    public PageDto<PartySummaryResponse> getGameParties(Long appid, Pageable pageable) {
+        SteamGame game = gameRepository.findSteamGameByAppid(appid)
+                .orElseThrow(ErrorCode.GAME_NOT_FOUND::throwServiceException);
+
+        Page<Party> page = partyRepository.findByGameId(game.getId(), pageable);
+        return new PageDto<>(page.map(PartySummaryResponse::from));
+    }
+
 
 }

--- a/src/main/java/com/ll/playon/domain/game/game/service/GameService.java
+++ b/src/main/java/com/ll/playon/domain/game/game/service/GameService.java
@@ -1,6 +1,7 @@
 package com.ll.playon.domain.game.game.service;
 
 import com.ll.playon.domain.game.game.dto.GameListResponse;
+import com.ll.playon.domain.game.game.dto.response.GameDetailWithPartyResponse;
 import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.game.game.entity.SteamGenre;
 import com.ll.playon.domain.game.game.repository.GameRepository;
@@ -8,10 +9,18 @@ import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.member.entity.MemberSteamData;
 import com.ll.playon.domain.member.repository.MemberRepository;
 import com.ll.playon.domain.member.repository.MemberSteamDataRepository;
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.party.repository.PartyRepository;
+import com.ll.playon.domain.party.partyLog.entity.PartyLog;
+import com.ll.playon.domain.party.partyLog.repository.PartyLogRepository;
 import com.ll.playon.global.exceptions.ErrorCode;
 import com.ll.playon.global.steamAPI.SteamAPI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +34,8 @@ public class GameService {
     private final SteamAPI steamAPI;
     private final MemberSteamDataRepository memberSteamDataRepository;
     private final MemberRepository memberRepository;
+    private final PartyRepository partyRepository;
+    private final PartyLogRepository partyLogRepository;
 
     private final static int TOP_FIVE = 5;
 
@@ -94,4 +105,24 @@ public class GameService {
     public void updateDB(Long appId) {
 
     }
+
+    @Transactional(readOnly = true)
+    public GameDetailWithPartyResponse getGameDetailWithParties(
+            Long appid,
+            Pageable partyPageable,
+            Pageable logPageable
+    ) {
+        SteamGame game = gameRepository.findSteamGameByAppid(appid)
+                .orElseThrow(ErrorCode.GAME_NOT_FOUND::throwServiceException);
+
+        Page<Party> partyPage = partyRepository.findByGameId(game.getId(), partyPageable);
+        Page<PartyLog> logPage = partyLogRepository.findByPartyGameId(game.getId(), logPageable);
+
+        return GameDetailWithPartyResponse.from(
+                game,
+                partyPage.getContent(),
+                logPage.getContent()
+        );
+    }
+
 }

--- a/src/main/java/com/ll/playon/domain/game/game/service/GameService.java
+++ b/src/main/java/com/ll/playon/domain/game/game/service/GameService.java
@@ -1,7 +1,10 @@
 package com.ll.playon.domain.game.game.service;
 
 import com.ll.playon.domain.game.game.dto.GameListResponse;
+import com.ll.playon.domain.game.game.dto.request.GameSearchCondition;
+import com.ll.playon.domain.game.game.dto.response.GameAutoCompleteResponse;
 import com.ll.playon.domain.game.game.dto.response.GameDetailWithPartyResponse;
+import com.ll.playon.domain.game.game.dto.response.GameSummaryResponse;
 import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.game.game.entity.SteamGenre;
 import com.ll.playon.domain.game.game.repository.GameRepository;
@@ -15,6 +18,7 @@ import com.ll.playon.domain.party.partyLog.entity.PartyLog;
 import com.ll.playon.domain.party.partyLog.repository.PartyLogRepository;
 import com.ll.playon.global.exceptions.ErrorCode;
 import com.ll.playon.global.steamAPI.SteamAPI;
+import com.ll.playon.standard.page.dto.PageDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -123,6 +127,20 @@ public class GameService {
                 partyPage.getContent(),
                 logPage.getContent()
         );
+    }
+
+    @Transactional(readOnly = true)
+    public PageDto<GameSummaryResponse> searchGames(GameSearchCondition condition, Pageable pageable) {
+        Page<SteamGame> result = gameRepository.searchGames(condition, pageable);
+        return new PageDto<>(result.map(GameSummaryResponse::from));
+    }
+
+    @Transactional(readOnly = true)
+    public List<GameAutoCompleteResponse> autoCompleteGames(String keyword) {
+        return gameRepository.searchByGameName(keyword)
+                .stream()
+                .map(GameAutoCompleteResponse::from)
+                .toList();
     }
 
 }

--- a/src/main/java/com/ll/playon/domain/party/party/entity/PartyMember.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/PartyMember.java
@@ -14,11 +14,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Table(
@@ -29,6 +25,8 @@ import lombok.Setter;
 )
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PartyMember extends BaseTime {
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -107,4 +107,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
     List<PartyMember> findPartyMembersByPartyIds(@Param("partyIds") List<Long> partyIds);
 
     List<Party> findAllByPartyStatusOrderByPartyAtDescCreatedAtDesc(PartyStatus partyStatus, Pageable pageable);
+
+    @Query("SELECT p FROM Party p WHERE p.game = :gameId")
+    Page<Party> findByGameId(@Param("gameId") Long gameId, Pageable pageable);
 }

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -109,5 +109,5 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
     List<Party> findAllByPartyStatusOrderByPartyAtDescCreatedAtDesc(PartyStatus partyStatus, Pageable pageable);
 
     @Query("SELECT p FROM Party p WHERE p.game = :gameId")
-    Page<Party> findByGameId(@Param("gameId") Long gameId, Pageable pageable);
+    Page<Party> findByGameId(@Param("gameId") Long gameId, Pageable partyPageable);
 }

--- a/src/main/java/com/ll/playon/domain/party/partyLog/repository/PartyLogRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/repository/PartyLogRepository.java
@@ -1,7 +1,13 @@
 package com.ll.playon.domain.party.partyLog.repository;
 
 import com.ll.playon.domain.party.partyLog.entity.PartyLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PartyLogRepository extends JpaRepository<PartyLog, Long> {
+    @Query("SELECT pl FROM PartyLog pl WHERE pl.partyMember.party.game = :gameId")
+    Page<PartyLog> findByPartyGameId(@Param("gameId") Long gameId, Pageable pageable);
 }

--- a/src/main/java/com/ll/playon/domain/party/partyLog/repository/PartyLogRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/repository/PartyLogRepository.java
@@ -9,5 +9,5 @@ import org.springframework.data.repository.query.Param;
 
 public interface PartyLogRepository extends JpaRepository<PartyLog, Long> {
     @Query("SELECT pl FROM PartyLog pl WHERE pl.partyMember.party.game = :gameId")
-    Page<PartyLog> findByPartyGameId(@Param("gameId") Long gameId, Pageable pageable);
+    Page<PartyLog> findByPartyGameId(@Param("gameId") Long gameId, Pageable logPageable);
 }

--- a/src/main/java/com/ll/playon/global/config/WebConfig.java
+++ b/src/main/java/com/ll/playon/global/config/WebConfig.java
@@ -1,0 +1,10 @@
+package com.ll.playon.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+@Configuration
+@EnableSpringDataWebSupport
+public class WebConfig {
+}
+

--- a/src/test/java/com/ll/playon/domain/game/controller/GameControllerTest.java
+++ b/src/test/java/com/ll/playon/domain/game/controller/GameControllerTest.java
@@ -1,10 +1,20 @@
 package com.ll.playon.domain.game.controller;
 
 import com.ll.playon.domain.game.game.controller.GameController;
+import com.ll.playon.domain.game.game.entity.SteamGame;
+import com.ll.playon.domain.game.game.repository.GameRepository;
 import com.ll.playon.domain.member.TestMemberHelper;
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.domain.party.party.repository.PartyRepository;
+import com.ll.playon.domain.party.partyLog.entity.PartyLog;
+import com.ll.playon.domain.party.partyLog.repository.PartyLogRepository;
+import com.ll.playon.domain.party.party.type.PartyRole;
 import com.ll.playon.global.openFeign.SteamStoreClient;
 import com.ll.playon.global.openFeign.dto.GameItem;
 import com.ll.playon.global.openFeign.dto.SteamSearchResponse;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -15,8 +25,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -29,14 +40,42 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 public class GameControllerTest {
 
-    @Autowired
-    private MockMvc mvc;
+    @Autowired private MockMvc mvc;
+    @Autowired private GameRepository gameRepository;
+    @Autowired private PartyRepository partyRepository;
+    @Autowired private PartyLogRepository partyLogRepository;
 
-    @Autowired
-    private TestMemberHelper testMemberHelper;
+    @Autowired private TestMemberHelper testMemberHelper;
 
     @MockitoBean
     private SteamStoreClient mockSteamStoreClient;
+
+    private SteamGame game;
+
+    @BeforeEach
+    void setup() {
+        partyLogRepository.deleteAll();
+        partyRepository.deleteAll();
+        gameRepository.deleteAll();
+
+        game = gameRepository.save(SteamGame.builder()
+                .appid(12345L)
+                .name("Test Game")
+                .releaseDate(LocalDate.of(2023, 1, 1))
+                .headerImage("image.jpg")
+                .shortDescription("Short desc")
+                .aboutTheGame("About the game")
+                .requiredAge(19)
+                .website("http://test.com")
+                .isWindowsSupported(true)
+                .isMacSupported(true)
+                .isLinuxSupported(false)
+                .isSinglePlayer(true)
+                .isMultiPlayer(true)
+                .developers("Dev")
+                .publishers("Pub")
+                .build());
+    }
 
     private void setFakeRakingResponse() {
         SteamSearchResponse fakeSteamRankingResponse = new SteamSearchResponse();
@@ -52,7 +91,6 @@ public class GameControllerTest {
         fakeSteamRankingResponse.setDesc("");
         fakeSteamRankingResponse.setItems(List.of(gameItem1, gameItem2));
 
-
         Mockito.when(mockSteamStoreClient.getGameRanking())
                 .thenReturn(fakeSteamRankingResponse);
     }
@@ -63,9 +101,7 @@ public class GameControllerTest {
         setFakeRakingResponse();
 
         ResultActions resultActions = mvc
-                .perform(
-                        get("/api/games/ranking")
-                )
+                .perform(get("/api/games/ranking"))
                 .andDo(print());
 
         resultActions
@@ -87,5 +123,110 @@ public class GameControllerTest {
                 .andExpect(handler().handlerType(GameController.class))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").exists());
+    }
+
+    @Test
+    @DisplayName("게임 상세 정보 조회 성공")
+    void getGameDetailSuccess() throws Exception {
+        mvc.perform(get("/api/games/{appid}/details", game.getAppid())
+                        .param("partyPage.page", "0")
+                        .param("partyPage.size", "3")
+                        .param("logPage.page", "0")
+                        .param("logPage.size", "3"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.game.appid").value(game.getAppid()))
+                .andExpect(jsonPath("$.data.game.name").value(game.getName()))
+                .andExpect(jsonPath("$.data.partyList").isArray())
+                .andExpect(jsonPath("$.data.partyLogList").isArray());
+
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게임 조회 실패")
+    void getGameDetailNotFound() throws Exception {
+        mvc.perform(get("/api/games/99999/details"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("게임 목록 조회 - 성공")
+    void getGameListSuccess() throws Exception {
+        mvc.perform(get("/api/games/list"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items").isArray())
+                .andExpect(jsonPath("$.data.items[0].appid").value(game.getAppid()));
+    }
+
+    @Test
+    @DisplayName("게임 자동완성 검색 - 성공")
+    void autoCompleteSuccess() throws Exception {
+        mvc.perform(get("/api/games/search").param("keyword", "Test"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].name").value("Test Game"));
+    }
+
+    @Test
+    @DisplayName("게임별 파티 목록 조회 - 성공")
+    void getGamePartiesSuccess() throws Exception {
+        Party party = partyRepository.save(Party.builder()
+                .game(game.getId())
+                .name("Test Party")
+                .partyAt(LocalDateTime.now().plusDays(1))
+                .isPublic(true)
+                .minimum(1)
+                .maximum(5)
+                .build());
+
+        mvc.perform(get("/api/games/{appid}/party", game.getAppid()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items").isArray())
+                .andExpect(jsonPath("$.data.items[0].name").value("Test Party"));
+    }
+
+    @Test
+    @DisplayName("게임별 파티 목록 조회 - 존재하지 않는 게임 ID")
+    void getGamePartiesFailWhenGameNotFound() throws Exception {
+        mvc.perform(get("/api/games/{appid}/party", 99999))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("게임별 파티 로그 조회 - 성공")
+    void getGamePartyLogsSuccess() throws Exception {
+        Party party = partyRepository.save(Party.builder()
+                .game(game.getId())
+                .name("Logged Party")
+                .partyAt(LocalDateTime.now().minusDays(1))
+                .isPublic(true)
+                .minimum(1)
+                .maximum(4)
+                .build());
+
+        PartyMember member = PartyMember.builder()
+                .party(party)
+                .partyRole(PartyRole.OWNER)
+                .mvpPoint(0)
+                .build();
+
+        party.getPartyMembers().add(member);
+
+        PartyLog log = partyLogRepository.save(PartyLog.builder()
+                .partyMember(member)
+                .comment("Good game")
+                .content("Enjoyed it")
+                .build());
+
+        mvc.perform(get("/api/games/{appid}/logs", game.getAppid()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items").isArray())
+                .andExpect(jsonPath("$.data.items[0].partyId").value(party.getId()));
+    }
+
+    @Test
+    @DisplayName("게임별 파티 로그 조회 - 존재하지 않는 게임 ID")
+    void getGamePartyLogsFailWhenGameNotFound() throws Exception {
+        mvc.perform(get("/api/games/{appid}/logs", 99999))
+                .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/ll/playon/domain/game/controller/GameControllerTest.java
+++ b/src/test/java/com/ll/playon/domain/game/controller/GameControllerTest.java
@@ -44,7 +44,6 @@ public class GameControllerTest {
     @Autowired private GameRepository gameRepository;
     @Autowired private PartyRepository partyRepository;
     @Autowired private PartyLogRepository partyLogRepository;
-
     @Autowired private TestMemberHelper testMemberHelper;
 
     @MockitoBean
@@ -78,21 +77,20 @@ public class GameControllerTest {
     }
 
     private void setFakeRakingResponse() {
-        SteamSearchResponse fakeSteamRankingResponse = new SteamSearchResponse();
-        GameItem gameItem1 = new GameItem();
-        GameItem gameItem2 = new GameItem();
+        SteamSearchResponse fakeResponse = new SteamSearchResponse();
+        GameItem game1 = new GameItem();
+        GameItem game2 = new GameItem();
 
-        gameItem1.setName("Counter-Strike 2");
-        gameItem1.setLogo("https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/730/header.jpg");
+        game1.setName("Counter-Strike 2");
+        game1.setLogo("https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/730/header.jpg");
 
-        gameItem2.setName("Dota 2");
-        gameItem2.setLogo("https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/570/header.jpg");
+        game2.setName("Dota 2");
+        game2.setLogo("https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/570/header.jpg");
 
-        fakeSteamRankingResponse.setDesc("");
-        fakeSteamRankingResponse.setItems(List.of(gameItem1, gameItem2));
+        fakeResponse.setDesc("");
+        fakeResponse.setItems(List.of(game1, game2));
 
-        Mockito.when(mockSteamStoreClient.getGameRanking())
-                .thenReturn(fakeSteamRankingResponse);
+        Mockito.when(mockSteamStoreClient.getGameRanking()).thenReturn(fakeResponse);
     }
 
     @Test
@@ -138,18 +136,17 @@ public class GameControllerTest {
                 .andExpect(jsonPath("$.data.game.name").value(game.getName()))
                 .andExpect(jsonPath("$.data.partyList").isArray())
                 .andExpect(jsonPath("$.data.partyLogList").isArray());
-
     }
 
     @Test
     @DisplayName("존재하지 않는 게임 조회 실패")
-    void getGameDetailNotFound() throws Exception {
-        mvc.perform(get("/api/games/99999/details"))
+    void getGameDetailFailWhenGameNotFound() throws Exception {
+        mvc.perform(get("/api/games/{appid}/details", 99999))
                 .andExpect(status().isNotFound());
     }
 
     @Test
-    @DisplayName("게임 목록 조회 - 성공")
+    @DisplayName("게임 목록 조회 성공")
     void getGameListSuccess() throws Exception {
         mvc.perform(get("/api/games/list"))
                 .andExpect(status().isOk())
@@ -158,16 +155,17 @@ public class GameControllerTest {
     }
 
     @Test
-    @DisplayName("게임 자동완성 검색 - 성공")
+    @DisplayName("게임 자동완성 검색 성공")
     void autoCompleteSuccess() throws Exception {
-        mvc.perform(get("/api/games/search").param("keyword", "Test"))
+        mvc.perform(get("/api/games/search")
+                        .param("keyword", "Test"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data[0].name").value("Test Game"));
     }
 
     @Test
-    @DisplayName("게임별 파티 목록 조회 - 성공")
+    @DisplayName("게임별 파티 목록 조회 성공")
     void getGamePartiesSuccess() throws Exception {
         Party party = partyRepository.save(Party.builder()
                 .game(game.getId())
@@ -185,14 +183,14 @@ public class GameControllerTest {
     }
 
     @Test
-    @DisplayName("게임별 파티 목록 조회 - 존재하지 않는 게임 ID")
+    @DisplayName("게임별 파티 목록 조회 실패 - 존재하지 않는 게임 ID")
     void getGamePartiesFailWhenGameNotFound() throws Exception {
         mvc.perform(get("/api/games/{appid}/party", 99999))
                 .andExpect(status().isNotFound());
     }
 
     @Test
-    @DisplayName("게임별 파티 로그 조회 - 성공")
+    @DisplayName("게임별 파티 로그 조회 성공")
     void getGamePartyLogsSuccess() throws Exception {
         Party party = partyRepository.save(Party.builder()
                 .game(game.getId())
@@ -224,7 +222,7 @@ public class GameControllerTest {
     }
 
     @Test
-    @DisplayName("게임별 파티 로그 조회 - 존재하지 않는 게임 ID")
+    @DisplayName("게임별 파티 로그 조회 실패 - 존재하지 않는 게임 ID")
     void getGamePartyLogsFailWhenGameNotFound() throws Exception {
         mvc.perform(get("/api/games/{appid}/logs", 99999))
                 .andExpect(status().isNotFound());


### PR DESCRIPTION
🎮 게임 상세 기능 구현
1. 게임 검색 및 조회
게임명 키워드 기반 자동완성 검색 기능 구현

2. 게임 상세 정보 조회
/api/games/{appid}/details API 구현
단일 게임에 대한 상세 정보 (설명, 지원 플랫폼, 개발사 등) 응답
함께 해당 게임에 대한 파티 목록과 파티 로그도 함께 포함하여 반환

3. 게임별 파티 목록 조회
/api/games/{appid}/party API 추가
해당 게임의 파티 목록을 페이징 처리하여 반환

4. 게임별 파티 로그 조회
/api/games/{appid}/logs API 추가
해당 게임의 파티 로그를 페이징 처리하여 반환

✅ 테스트 코드
위 기능 모두에 대한 단위 테스트 작성 완료