### PR TITLE
[FIX] GameControllerTest 오류 수정

### DIFF
--- a/src/main/java/com/ll/playon/domain/game/game/service/GameService.java
+++ b/src/main/java/com/ll/playon/domain/game/game/service/GameService.java
@@ -118,8 +118,8 @@ public class GameService {
         SteamGame game = gameRepository.findSteamGameByAppid(appid)
                 .orElseThrow(ErrorCode.GAME_NOT_FOUND::throwServiceException);
 
-        Page<Party> partyPage = partyRepository.findByGameId(game.getId(), partyPageable);
-        Page<PartyLog> logPage = partyLogRepository.findByPartyGameId(game.getId(), logPageable);
+        Page<Party> partyPage = partyRepository.findByGame(game, partyPageable);
+        Page<PartyLog> logPage = partyLogRepository.findByPartyGame(game, logPageable);
 
         return GameDetailWithPartyResponse.from(
                 game,
@@ -147,7 +147,7 @@ public class GameService {
         SteamGame game = gameRepository.findSteamGameByAppid(appid)
                 .orElseThrow(ErrorCode.GAME_NOT_FOUND::throwServiceException);
 
-        Page<Party> page = partyRepository.findByGameId(game.getId(), pageable);
+        Page<Party> page = partyRepository.findByGame(game, pageable);
         return new PageDto<>(page.map(PartySummaryResponse::from));
     }
 
@@ -156,7 +156,7 @@ public class GameService {
         SteamGame game = gameRepository.findSteamGameByAppid(appid)
                 .orElseThrow(ErrorCode.GAME_NOT_FOUND::throwServiceException);
 
-        Page<PartyLog> page = partyLogRepository.findByPartyGameId(game.getId(), pageable);
+        Page<PartyLog> page = partyLogRepository.findByPartyGame(game, pageable);
         return new PageDto<>(page.map(PartyLogSummaryResponse::from));
     }
 

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -1,5 +1,6 @@
 package com.ll.playon.domain.party.party.repository;
 
+import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.party.party.entity.Party;
 import com.ll.playon.domain.party.party.entity.PartyMember;
 import com.ll.playon.domain.party.party.entity.PartyTag;
@@ -190,8 +191,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             """)
     List<PartyMember> findPartyMembersByPartyIds(@Param("partyIds") List<Long> partyIds);
 
-    @Query("SELECT p FROM Party p WHERE p.game = :gameId")
-    Page<Party> findByGameId(@Param("gameId") Long gameId, Pageable partyPageable);
+    Page<Party> findByGame(SteamGame game, Pageable pageable);
 
 
     @Query("""

--- a/src/main/java/com/ll/playon/domain/party/partyLog/repository/PartyLogRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/repository/PartyLogRepository.java
@@ -1,5 +1,6 @@
 package com.ll.playon.domain.party.partyLog.repository;
 
+import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.party.partyLog.entity.PartyLog;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -8,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PartyLogRepository extends JpaRepository<PartyLog, Long> {
-    @Query("SELECT pl FROM PartyLog pl WHERE pl.partyMember.party.game = :gameId")
-    Page<PartyLog> findByPartyGameId(@Param("gameId") Long gameId, Pageable logPageable);
+    @Query("SELECT pl FROM PartyLog pl WHERE pl.partyMember.party.game = :game")
+    Page<PartyLog> findByPartyGame(@Param("game") SteamGame game, Pageable pageable);
+
 }

--- a/src/test/java/com/ll/playon/domain/game/controller/GameControllerTest.java
+++ b/src/test/java/com/ll/playon/domain/game/controller/GameControllerTest.java
@@ -136,16 +136,16 @@ public class GameControllerTest {
     @Test
     @DisplayName("게임 상세 정보 조회 성공")
     void getGameDetailSuccess() throws Exception {
-//        mvc.perform(get("/api/games/{appid}/details", game.getAppid())
-//                        .param("partyPage.page", "0")
-//                        .param("partyPage.size", "3")
-//                        .param("logPage.page", "0")
-//                        .param("logPage.size", "3"))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.data.game.appid").value(game.getAppid()))
-//                .andExpect(jsonPath("$.data.game.name").value(game.getName()))
-//                .andExpect(jsonPath("$.data.partyList").isArray())
-//                .andExpect(jsonPath("$.data.partyLogList").isArray());
+        mvc.perform(get("/api/games/{appid}/details", game.getAppid())
+                        .param("partyPage.page", "0")
+                        .param("partyPage.size", "3")
+                        .param("logPage.page", "0")
+                        .param("logPage.size", "3"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.game.appid").value(game.getAppid()))
+                .andExpect(jsonPath("$.data.game.name").value(game.getName()))
+                .andExpect(jsonPath("$.data.partyList").isArray())
+                .andExpect(jsonPath("$.data.partyLogList").isArray());
     }
 
     @Test
@@ -186,10 +186,10 @@ public class GameControllerTest {
                 .maximum(5)
                 .build());
 
-//        mvc.perform(get("/api/games/{appid}/party", game.getAppid()))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.data.items").isArray())
-//                .andExpect(jsonPath("$.data.items[0].name").value("Test Party"));
+        mvc.perform(get("/api/games/{appid}/party", game.getAppid()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items").isArray())
+                .andExpect(jsonPath("$.data.items[0].name").value("Test Party"));
     }
 
     @Test
@@ -225,10 +225,10 @@ public class GameControllerTest {
                 .content("Enjoyed it")
                 .build());
 
-//        mvc.perform(get("/api/games/{appid}/logs", game.getAppid()))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.data.items").isArray())
-//                .andExpect(jsonPath("$.data.items[0].partyId").value(party.getId()));
+        mvc.perform(get("/api/games/{appid}/logs", game.getAppid()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items").isArray())
+                .andExpect(jsonPath("$.data.items[0].partyId").value(party.getId()));
     }
 
     @Test


### PR DESCRIPTION
1. 게임 상세 조회 오류 수정

- 기존 JPQL 쿼리에서 p.game = :gameId로 잘못된 타입(Long ↔ SteamGame) 매칭으로 인해 InvalidDataAccessApiUsageException 발생

- @Query 제거 후, Spring Data JPA 메서드 네이밍 기반으로 findByGame(SteamGame game, Pageable pageable) 메서드 사용

2. 게임별 파티 목록 조회 기능 수정

- findByGameId(Long gameId, Pageable pageable) → findByGame(SteamGame game, Pageable pageable) 로 수정

- Service에서 SteamGame 조회 후 전달하는 구조로 통일

3. 게임별 파티 로그 조회 기능 수정

- PartyLog 조회 시도 시 발생한 Entity 타입 미스매칭 해결

- 동일하게 SteamGame 엔티티 객체를 기준으로 Repository 메서드 재정의 및 호출 방식 수정

