### PR TITLE
[FEAT] 플레이타임 긴 게임

### DIFF
--- a/src/main/java/com/ll/playon/domain/game/game/controller/GameController.java
+++ b/src/main/java/com/ll/playon/domain/game/game/controller/GameController.java
@@ -94,14 +94,20 @@ public class GameController {
 
     @GetMapping("/popular")
     @Operation(summary = "유저가 많이 선택한 게임")
-    public RsData<List<GetWeeklyPopularGameResponse>> popularGames() {
+    public RsData<List<GetWeeklyPopularGameResponse>> getWeeklyPopularGames() {
         return RsData.success(HttpStatus.OK, gameService.getWeeklyPopularGames(LocalDate.now().with(DayOfWeek.MONDAY)));
     }
 
     @GetMapping("/recommend/friends")
     @Operation(summary = "최근 함께 파티한 유저의 게임")
-    public RsData<List<GetRecommendedGameResponse>> recommendGames(@RequestParam(defaultValue = "4") int count) {
-        return RsData.success(HttpStatus.OK, gameService.recommendGamesForMember(userContext.getActor().getId(), count));
+    public RsData<List<GetRecommendedGameResponse>> getFriendRecommendedGames() {
+        return RsData.success(HttpStatus.OK, gameService.recommendGamesForMember(userContext.getActor().getId()));
+    }
+
+    @GetMapping("/recommend/playtime/top")
+    @Operation(summary = "플레이타임 긴 게임")
+    public RsData<List<GetRecommendedGameResponse>> getTopPlaytimeGames() {
+        return RsData.success(HttpStatus.OK, gameService.getTopPlaytimeGames(LocalDate.now().with(DayOfWeek.MONDAY)));
     }
 
 }

--- a/src/main/java/com/ll/playon/domain/game/game/entity/LongPlaytimeGame.java
+++ b/src/main/java/com/ll/playon/domain/game/game/entity/LongPlaytimeGame.java
@@ -1,0 +1,30 @@
+package com.ll.playon.domain.game.game.entity;
+
+import com.ll.playon.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "long_playtime_game", indexes = {
+        @Index(name = "idx_week_start_date", columnList = "week_start_date"),
+        @Index(name = "idx_week_start_date_playtime", columnList = "week_start_date, total_playtime DESC")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class LongPlaytimeGame extends BaseEntity {
+    @Column(name = "appid", nullable = false)
+    private Long appid;
+
+    @Column(name = "total_playtime", nullable = false)
+    private Long totalPlaytime;
+
+    @Column(name = "week_start_date", nullable = false)
+    private LocalDate weekStartDate;
+}

--- a/src/main/java/com/ll/playon/domain/game/scheduler/repository/LongPlaytimeGameRepository.java
+++ b/src/main/java/com/ll/playon/domain/game/scheduler/repository/LongPlaytimeGameRepository.java
@@ -1,0 +1,14 @@
+package com.ll.playon.domain.game.scheduler.repository;
+
+import com.ll.playon.domain.game.game.entity.LongPlaytimeGame;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface LongPlaytimeGameRepository extends JpaRepository<LongPlaytimeGame, Long> {
+    @Query("SELECT appid FROM LongPlaytimeGame WHERE weekStartDate = :week ORDER BY totalPlaytime DESC")
+    List<Long> findAppIdsByWeek(@Param("week") LocalDate weekStartDate);
+}

--- a/src/main/java/com/ll/playon/domain/game/scheduler/repository/WeeklyGameRepository.java
+++ b/src/main/java/com/ll/playon/domain/game/scheduler/repository/WeeklyGameRepository.java
@@ -9,6 +9,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface WeeklyGameRepository extends JpaRepository<WeeklyPopularGame, Long> {
-    @Query("SELECT w.appid FROM WeeklyPopularGame w WHERE w.weekStartDate = :weekStartDate ORDER BY w.playCount DESC")
+    @Query("SELECT appid FROM WeeklyPopularGame WHERE weekStartDate = :weekStartDate ORDER BY playCount DESC")
     List<Long> findTopGameIdsByWeek(@Param("weekStartDate") LocalDate weekStartDate);
 }

--- a/src/main/java/com/ll/playon/domain/game/scheduler/scheduler/GameScheduler.java
+++ b/src/main/java/com/ll/playon/domain/game/scheduler/scheduler/GameScheduler.java
@@ -1,6 +1,8 @@
 package com.ll.playon.domain.game.scheduler.scheduler;
 
+import com.ll.playon.domain.game.game.entity.LongPlaytimeGame;
 import com.ll.playon.domain.game.game.entity.WeeklyPopularGame;
+import com.ll.playon.domain.game.scheduler.repository.LongPlaytimeGameRepository;
 import com.ll.playon.domain.game.scheduler.repository.WeeklyGameRepository;
 import com.ll.playon.domain.party.party.repository.PartyRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,8 @@ import java.util.List;
 public class GameScheduler {
     private final PartyRepository partyRepository;
     private final WeeklyGameRepository weeklyGameRepository;
+    private final LongPlaytimeGameRepository longPlaytimeGameRepository;
+    final int limit = 3;
 
     @Scheduled(cron = "0 0 0 * * MON") // 매주 월요일 00:00
 //    @Scheduled(cron = "0 * * * * *")
@@ -27,20 +31,34 @@ public class GameScheduler {
         LocalDateTime toDate = weekStart.atStartOfDay(); // 이번주
 
         updatePopularGames(fromDate, toDate, weekStart);
+        updateLongPlaytimeGames(fromDate, toDate, weekStart);
     }
 
-    public void updatePopularGames(LocalDateTime fromDate, LocalDateTime toDate, LocalDate weekStart) {
-        final int limit = 3;
-
+    // 유저가 많이 선택한 게임
+    private void updatePopularGames(LocalDateTime fromDate, LocalDateTime toDate, LocalDate weekStart) {
         List<WeeklyPopularGame> list = partyRepository.findTopGamesByPartyLastWeek(fromDate, toDate, PageRequest.of(0, limit))
                 .stream()
                 .map(row -> WeeklyPopularGame.builder()
                         .appid((Long) row.get("appid"))
-                        .playCount(((Number) row.get("playCount")).longValue())
+                        .playCount((Long) row.get("playCount"))
                         .weekStartDate(weekStart)
                         .build())
                 .toList();
 
         weeklyGameRepository.saveAll(list);
+    }
+
+    // 플레이 타임 긴 게임
+    private void updateLongPlaytimeGames(LocalDateTime fromDate, LocalDateTime toDate, LocalDate weekStart) {
+        List<LongPlaytimeGame> list = partyRepository.findTopGamesByPlaytimeLastWeek(fromDate, toDate, PageRequest.of(0, limit))
+                .stream()
+                .map(row -> LongPlaytimeGame.builder()
+                        .appid((Long) row.get("appid"))
+                        .totalPlaytime(((Number) row.get("playtime")).longValue())
+                        .weekStartDate(weekStart)
+                        .build())
+                .toList();
+
+        longPlaytimeGameRepository.saveAll(list);
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -223,4 +223,20 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
         ORDER BY p.createdAt DESC
     """)
     List<Party> findPublicCompletedPartiesIn(@Param("partyIds") List<Long> partyIds, Pageable pageable);
+
+    @Query(value = """
+    SELECT p.game_id AS appid,
+           SUM(TIMESTAMPDIFF(SECOND, p.party_at, p.ended_at)) / 3600 AS playtime
+    FROM party p
+    WHERE p.party_at >= :fromDate
+      AND p.party_at < :toDate
+      AND p.is_public = true
+      AND p.party_status = 'COMPLETED'
+      AND p.ended_at IS NOT NULL
+    GROUP BY p.game_id
+    ORDER BY playtime DESC
+    """,
+            countQuery = "SELECT COUNT(*) FROM party p",
+            nativeQuery = true)
+    List<Map<String, Object>> findTopGamesByPlaytimeLastWeek(@Param("fromDate") LocalDateTime fromDate, @Param("toDate") LocalDateTime toDate, Pageable pageable);
 }


### PR DESCRIPTION
## 작업 내용
- 최근 일주일 내 완료 + 공개 파티 기준으로 플레이타임이 긴 게임 집계
- `LongPlaytimeGame` 엔티티 추가 및 스케줄링 기능 구현
  - 매주 월요일 00:00 기준 지난주 데이터 기반으로 계산
  - partyAt ~ endedAt 시간 차이로 플레이타임 측정
- 상위 3개 게임을 저장 후 조회 API 구현 (`/api/games/recommend/playtime/top`)
- 플레이타임 집계는 초 단위로 계산
- 결과는 시간 단위로 변환 저장
- 추후 유저가 많이 선택한 게임과 함께 배치처리

CLOSES #61 