### PR TITLE
[FIX] RDS 연동 중 테이블 생성 시 발생하는 에러 수정

### DIFF
--- a/src/main/java/com/ll/playon/domain/game/game/entity/SteamGame.java
+++ b/src/main/java/com/ll/playon/domain/game/game/entity/SteamGame.java
@@ -11,8 +11,7 @@ import java.util.List;
 @Entity
 @Table(name = "steam_game", indexes = {
         @Index(name = "idx_game_appid", columnList = "appid"),
-        @Index(name = "idx_game_name", columnList = "name"),
-        @Index(name = "idx_game_genre", columnList = "id, genre_name")
+        @Index(name = "idx_game_name", columnList = "name")
 })
 @Getter
 @Setter

--- a/src/main/java/com/ll/playon/domain/notification/entity/Notification.java
+++ b/src/main/java/com/ll/playon/domain/notification/entity/Notification.java
@@ -23,17 +23,18 @@ public class Notification extends BaseTime {
     @Column(nullable = false)
     private NotificationType type;
 
-    @Column(nullable = false)
+    @Column(name = "is_read", nullable = false)
     @Builder.Default
-    private boolean read = false;
+    private boolean isRead = false;
+
 
     @URL
     private String redirectUrl;
 
     // 읽음 상태 변경 메서드
     public void markAsRead() {
-        if (!this.read) {
-            this.read = true;
+        if (!this.isRead) {
+            this.isRead = true;
         }
     }
 

--- a/src/main/java/com/ll/playon/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ll/playon/domain/notification/repository/NotificationRepository.java
@@ -12,5 +12,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findTop10ByReceiverIdOrderByCreatedAtDesc(Long memberId);
 
     // 요약용 : 안 읽은 알림 수 카운트
-    long countByReceiverIdAndReadFalse(Long receiverId);
+    long countByReceiverIdAndIsReadFalse(Long receiverId);
 }

--- a/src/main/java/com/ll/playon/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/ll/playon/domain/notification/service/NotificationService.java
@@ -79,7 +79,7 @@ public class NotificationService {
     @Transactional(readOnly = true)
     public NotificationSummaryResponse getNotificationSummary(Long memberId) {
         List<Notification> latest = notificationRepository.findTop10ByReceiverIdOrderByCreatedAtDesc(memberId);
-        long unreadCount = notificationRepository.countByReceiverIdAndReadFalse(memberId);
+        long unreadCount = notificationRepository.countByReceiverIdAndIsReadFalse(memberId);
 
         return NotificationSummaryResponse.of(latest, unreadCount);
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,4 +7,4 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
- [FIX] RDS 연동 중 테이블 생성 시 발생하는 에러 수정

1. Notification.java 엔티티에서 read -> isRead로 수정

2. SteamGame.java 엔티티에서 잘못된 인덱스 제거
"@Index(name = "idx_game_genre", columnList = "id, genre_name")"

3. application-dev.yml 에서MySQLDialect 수정