### PR TITLE
[FEAT] 길드 이미지 업로드

### DIFF
--- a/src/main/java/com/ll/playon/domain/guild/guild/controller/GuildController.java
+++ b/src/main/java/com/ll/playon/domain/guild/guild/controller/GuildController.java
@@ -5,18 +5,25 @@ import com.ll.playon.domain.guild.guild.dto.request.PostGuildRequest;
 import com.ll.playon.domain.guild.guild.dto.request.PutGuildRequest;
 import com.ll.playon.domain.guild.guild.dto.response.*;
 import com.ll.playon.domain.guild.guild.service.GuildService;
+import com.ll.playon.domain.image.type.ImageType;
+import com.ll.playon.global.aws.s3.S3Service;
 import com.ll.playon.global.response.RsData;
 import com.ll.playon.global.security.UserContext;
+import com.ll.playon.global.validation.FileValidator;
 import com.ll.playon.global.validation.GlobalValidation;
 import com.ll.playon.standard.page.dto.PageDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URL;
+import java.time.Instant;
 import java.util.List;
 
+@Tag(name = "Guild", description = "길드 기능")
 @RestController
 @RequestMapping("/api/guilds")
 @RequiredArgsConstructor
@@ -24,35 +31,51 @@ public class GuildController {
 
     private final GuildService guildService;
     private final UserContext userContext;
+    private final S3Service s3Service;
+
+    @GetMapping("/presigned-url")
+    @Operation(summary = "길드 대표 이미지 업로드용 Presigned URL 발급")
+    public RsData<URL> getPresignedUrl(@RequestParam String fileType) {
+        FileValidator.validateFileType(fileType); // 파일 타입 체크
+
+        // presigned URL은 아직 길드가 생성되기 전이므로 임시 ID 사용
+        return RsData.success(HttpStatus.OK, s3Service.generatePresignedUrl(ImageType.GUILD, Instant.now().getEpochSecond(), fileType));
+    }
 
     @PostMapping
+    @Operation(summary = "길드 생성")
     public RsData<PostGuildResponse> addGuild(@RequestBody @Valid PostGuildRequest request) {
         return RsData.success(HttpStatus.CREATED, guildService.createGuild(request, userContext.getActor()));
     }
 
     @PutMapping("/{guildId}")
+    @Operation(summary = "길드 수정")
     public RsData<PutGuildResponse> updateGuild(@PathVariable Long guildId,
                                                 @RequestBody @Valid PutGuildRequest request) {
         return RsData.success(HttpStatus.OK, guildService.modifyGuild(guildId, request, userContext.getActor()));
     }
 
     @DeleteMapping("/{guildId}")
+    @Operation(summary = "길드 삭제(길드장만 가능)")
     public RsData<String> deleteGuild(@PathVariable Long guildId) {
         guildService.deleteGuild(guildId, userContext.getActor());
         return RsData.success(HttpStatus.OK, "ok");
     }
 
     @GetMapping("/{guildId}")
+    @Operation(summary = "길드 상세 조회")
     public RsData<GetGuildDetailResponse> getGuildDetail(@PathVariable Long guildId) {
         return RsData.success(HttpStatus.OK, guildService.getGuildDetail(guildId, userContext.getActor()));
     }
 
 //    @GetMapping("/{guildId}/members")
+//    @Operation(summary = "길드 멤버 조회")
 //    public RsData<PageDto<GuildMemberDto>> getGuildMembers(@PathVariable Long guildId, Pageable pageable) {
 //        return RsData.success(HttpStatus.OK, guildService.getGuildMembers(guildId, userContext.getActor(), pageable));
 //    }
 
     @GetMapping
+    @Operation(summary = "길드 상세 검색")
     public RsData<PageDto<GetGuildListResponse>> searchGuilds(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int pageSize,
@@ -65,6 +88,7 @@ public class GuildController {
     }
 
     @GetMapping("/popular")
+    @Operation(summary = "인기 길드 조회")
     public RsData<List<GetPopularGuildResponse>> getPopularGuilds(@RequestParam(defaultValue = "10") int count) {
         return RsData.success(HttpStatus.OK, guildService.getPopularGuilds(count));
     }

--- a/src/main/java/com/ll/playon/domain/guild/guild/dto/request/PostGuildRequest.java
+++ b/src/main/java/com/ll/playon/domain/guild/guild/dto/request/PostGuildRequest.java
@@ -20,7 +20,6 @@ public record PostGuildRequest(
 
         Long appid,
 
-        @NotBlank(message = "길드 대표 이미지는 필수입니다.")
         String guildImg,
 
         @NotNull(message = "태그 정보들을 입력해주세요.")

--- a/src/main/java/com/ll/playon/domain/guild/guild/dto/request/PutGuildRequest.java
+++ b/src/main/java/com/ll/playon/domain/guild/guild/dto/request/PutGuildRequest.java
@@ -21,7 +21,6 @@ public record PutGuildRequest(
 
         boolean isPublic,
 
-        @NotBlank(message = "길드 대표 이미지는 필수입니다.")
         String guildImg,
 
         @NotNull(message = "태그 정보들을 입력해주세요.")

--- a/src/main/java/com/ll/playon/domain/guild/guild/entity/Guild.java
+++ b/src/main/java/com/ll/playon/domain/guild/guild/entity/Guild.java
@@ -58,9 +58,9 @@ public class Guild extends BaseTime {
 
     public void softDelete() {
         this.isDeleted = true;
-        this.members.clear();
         this.name = "DELETED_" + UUID.randomUUID();
         this.description = "DELETED";
+        this.guildImg = "DELETED";
     }
 
     public void updateFromRequest(PutGuildRequest request, SteamGame game) {

--- a/src/main/java/com/ll/playon/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/ll/playon/domain/image/repository/ImageRepository.java
@@ -2,11 +2,12 @@ package com.ll.playon.domain.image.repository;
 
 import com.ll.playon.domain.image.entity.Image;
 import com.ll.playon.domain.image.type.ImageType;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
     List<Image> findAllByImageTypeAndReferenceId(ImageType imageType, long referenceId);
@@ -36,7 +37,7 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
             AND i.imageUrl = :imageUrl
             """
     )
-    long deleteByReferenceIdAndImageUrl(
+    int deleteByReferenceIdAndImageUrl(
             @Param("imageType") ImageType imageType,
             @Param("referenceId") long referenceId,
             @Param("imageUrl") String imageUrl);

--- a/src/main/java/com/ll/playon/domain/image/service/ImageService.java
+++ b/src/main/java/com/ll/playon/domain/image/service/ImageService.java
@@ -5,12 +5,13 @@ import com.ll.playon.domain.image.mapper.ImageMapper;
 import com.ll.playon.domain.image.repository.ImageRepository;
 import com.ll.playon.domain.image.type.ImageType;
 import com.ll.playon.global.aws.s3.S3Service;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -83,7 +84,7 @@ public class ImageService {
     // DB에서 해당 ID에 존재하는 URL 삭제
     @Transactional
     public void deleteImagesByIdAndUrl(ImageType imageType, long referenceId, String url) {
-        long imageDeleteCount = StringUtils.isNotBlank(url)
+        int imageDeleteCount = StringUtils.isNotBlank(url)
                 ? this.imageRepository.deleteByReferenceIdAndImageUrl(imageType, referenceId, url) : 0;
 
         if (imageDeleteCount > 0) {

--- a/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     S3_PRESIGNED_URL_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PresignedURL 생성에 실패하였습니다."),
     S3_OBJECT_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 오브젝트 제거에 실패하였습니다."),
     S3_OBJECT_GET_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 오브젝트 호출에 실패하였습니다."),
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
 
     // 이미지
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."),

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -68,7 +68,7 @@ public class BaseInitData {
             self.makeSampleUsers();
             self.makeSampleGuilds();
             self.makeSampleWeeklyPopularGames();
-//            self.makeSampleParties();
+            self.makeSampleParties();
         };
     }
 

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -68,7 +68,7 @@ public class BaseInitData {
             self.makeSampleUsers();
             self.makeSampleGuilds();
             self.makeSampleWeeklyPopularGames();
-            self.makeSampleParties();
+//            self.makeSampleParties();
         };
     }
 

--- a/src/main/java/com/ll/playon/global/validation/FileValidator.java
+++ b/src/main/java/com/ll/playon/global/validation/FileValidator.java
@@ -1,0 +1,21 @@
+package com.ll.playon.global.validation;
+
+import com.ll.playon.global.exceptions.ErrorCode;
+
+import java.util.List;
+
+public class FileValidator {
+    private static final List<String> ALLOWED_TYPES = List.of("png", "jpg", "jpeg", "webp");
+
+    public static void validateFileType(String fileType) {
+        // 파일 타입이 없음
+        if (fileType == null || fileType.isBlank()) {
+            throw ErrorCode.INVALID_FILE_TYPE.throwServiceException();
+        }
+
+        // 허용되지 않는 파일 타입
+        if (!ALLOWED_TYPES.contains(fileType.toLowerCase())) {
+            throw ErrorCode.INVALID_FILE_TYPE.throwServiceException();
+        }
+    }
+}


### PR DESCRIPTION
### 구현기능
- Presigned URL을 이용한 길드 대표 이미지 업로드 기능 구현
- 길드 생성 시 이미지 URL을 함께 전달받아 DB(image 테이블)에 저장
    - 이미지를 저장하지 않는다면 조회시 프론트에서 기본 이미지 제공
- 길드 수정 시 이미지 변경 여부를 비교하여 기존 이미지 삭제 + 새 이미지 저장
- 길드 삭제 시
    - 연관 태그 및 멤버 제거
    - 이미지 URL 기준으로 S3 및 DB에서 삭제 처리(실제 S3 연결시 주석 해제 예정)
    - 길드 정보 마스킹(soft delete)

### 관련 이슈
#82 