### PR TITLE
[FEAT] 길드 인기 정렬 및 주간 활동량 기반 추천 기능 구현

### DIFF
--- a/src/main/java/com/ll/playon/domain/game/game/projection/TopPartyGameProjection.java
+++ b/src/main/java/com/ll/playon/domain/game/game/projection/TopPartyGameProjection.java
@@ -1,0 +1,6 @@
+package com.ll.playon.domain.game.game.projection;
+
+public interface TopPartyGameProjection {
+    Long getAppid();
+    Long getPlayCount();
+}

--- a/src/main/java/com/ll/playon/domain/game/game/projection/TopPlaytimeGameProjection.java
+++ b/src/main/java/com/ll/playon/domain/game/game/projection/TopPlaytimeGameProjection.java
@@ -1,0 +1,6 @@
+package com.ll.playon.domain.game.game.projection;
+
+public interface TopPlaytimeGameProjection {
+    Long getAppid();
+    Long getPlaytime();
+}

--- a/src/main/java/com/ll/playon/domain/game/game/repository/LongPlaytimeGameRepository.java
+++ b/src/main/java/com/ll/playon/domain/game/game/repository/LongPlaytimeGameRepository.java
@@ -1,4 +1,4 @@
-package com.ll.playon.domain.game.scheduler.repository;
+package com.ll.playon.domain.game.game.repository;
 
 import com.ll.playon.domain.game.game.entity.LongPlaytimeGame;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/ll/playon/domain/game/game/repository/WeeklyGameRepository.java
+++ b/src/main/java/com/ll/playon/domain/game/game/repository/WeeklyGameRepository.java
@@ -1,4 +1,4 @@
-package com.ll.playon.domain.game.scheduler.repository;
+package com.ll.playon.domain.game.game.repository;
 
 import com.ll.playon.domain.game.game.entity.WeeklyPopularGame;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/ll/playon/domain/game/game/scheduler/GameScheduler.java
+++ b/src/main/java/com/ll/playon/domain/game/game/scheduler/GameScheduler.java
@@ -1,9 +1,9 @@
-package com.ll.playon.domain.game.scheduler.scheduler;
+package com.ll.playon.domain.game.game.scheduler;
 
 import com.ll.playon.domain.game.game.entity.LongPlaytimeGame;
 import com.ll.playon.domain.game.game.entity.WeeklyPopularGame;
-import com.ll.playon.domain.game.scheduler.repository.LongPlaytimeGameRepository;
-import com.ll.playon.domain.game.scheduler.repository.WeeklyGameRepository;
+import com.ll.playon.domain.game.game.repository.LongPlaytimeGameRepository;
+import com.ll.playon.domain.game.game.repository.WeeklyGameRepository;
 import com.ll.playon.domain.party.party.repository.PartyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -39,12 +39,11 @@ public class GameScheduler {
         List<WeeklyPopularGame> list = partyRepository.findTopGamesByPartyLastWeek(fromDate, toDate, PageRequest.of(0, limit))
                 .stream()
                 .map(row -> WeeklyPopularGame.builder()
-                        .appid((Long) row.get("appid"))
-                        .playCount((Long) row.get("playCount"))
+                        .appid(row.getAppid())
+                        .playCount(row.getPlayCount())
                         .weekStartDate(weekStart)
                         .build())
                 .toList();
-
         weeklyGameRepository.saveAll(list);
     }
 
@@ -53,12 +52,11 @@ public class GameScheduler {
         List<LongPlaytimeGame> list = partyRepository.findTopGamesByPlaytimeLastWeek(fromDate, toDate, PageRequest.of(0, limit))
                 .stream()
                 .map(row -> LongPlaytimeGame.builder()
-                        .appid((Long) row.get("appid"))
-                        .totalPlaytime(((Number) row.get("playtime")).longValue())
+                        .appid(row.getAppid())
+                        .totalPlaytime(row.getPlaytime())
                         .weekStartDate(weekStart)
                         .build())
                 .toList();
-
         longPlaytimeGameRepository.saveAll(list);
     }
 }

--- a/src/main/java/com/ll/playon/domain/game/game/service/GameService.java
+++ b/src/main/java/com/ll/playon/domain/game/game/service/GameService.java
@@ -7,9 +7,9 @@ import com.ll.playon.domain.game.game.dto.response.*;
 import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.game.game.entity.SteamGenre;
 import com.ll.playon.domain.game.game.repository.GameRepository;
-import com.ll.playon.domain.game.scheduler.repository.LongPlaytimeGameRepository;
+import com.ll.playon.domain.game.game.repository.LongPlaytimeGameRepository;
 import com.ll.playon.domain.game.game.repository.GenreRepository;
-import com.ll.playon.domain.game.scheduler.repository.WeeklyGameRepository;
+import com.ll.playon.domain.game.game.repository.WeeklyGameRepository;
 import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.member.entity.MemberSteamData;
 import com.ll.playon.domain.member.repository.MemberRepository;
@@ -171,7 +171,6 @@ public class GameService {
 
         return gameIds.stream()
                 .map(gameMap::get)
-                .filter(Objects::nonNull)
                 .map(GetWeeklyPopularGameResponse::from)
                 .toList();
     }
@@ -221,9 +220,7 @@ public class GameService {
     @Transactional(readOnly = true)
     public List<GetRecommendedGameResponse> getTopPlaytimeGames(LocalDate week) {
         List<Long> appIds = longPlaytimeGameRepository.findAppIdsByWeek(week);
-
         List<SteamGame> games = gameRepository.findAllByIdIn(appIds);
-
         Map<Long, SteamGame> gameMap = games.stream()
                 .collect(Collectors.toMap(SteamGame::getId, g -> g));
 

--- a/src/main/java/com/ll/playon/domain/guild/guild/controller/GuildController.java
+++ b/src/main/java/com/ll/playon/domain/guild/guild/controller/GuildController.java
@@ -20,7 +20,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URL;
+import java.time.DayOfWeek;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 
 @Tag(name = "Guild", description = "길드 기능")
@@ -89,8 +91,8 @@ public class GuildController {
 
     @GetMapping("/popular")
     @Operation(summary = "인기 길드 조회")
-    public RsData<List<GetPopularGuildResponse>> getPopularGuilds(@RequestParam(defaultValue = "10") int count) {
-        return RsData.success(HttpStatus.OK, guildService.getPopularGuilds(count));
+    public RsData<List<GetPopularGuildResponse>> getPopularGuilds() {
+        return RsData.success(HttpStatus.OK, guildService.getPopularGuilds(LocalDate.now().with(DayOfWeek.MONDAY)));
     }
 
     @GetMapping("/recommend")

--- a/src/main/java/com/ll/playon/domain/guild/guild/entity/WeeklyPopularGuild.java
+++ b/src/main/java/com/ll/playon/domain/guild/guild/entity/WeeklyPopularGuild.java
@@ -1,0 +1,34 @@
+package com.ll.playon.domain.guild.guild.entity;
+
+import com.ll.playon.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "weekly_popular_guild", indexes = {
+        @Index(name = "idx_week_start_date", columnList = "week_start_date"),
+        @Index(name = "idx_week_start_date_post_count", columnList = "week_start_date, post_count DESC")
+})
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class WeeklyPopularGuild extends BaseEntity {
+
+    @Column(name = "guild_id", nullable = false)
+    private Long guildId;
+
+    @Column(name = "post_count", nullable = false)
+    private Long postCount;
+
+    @Column(name = "week_start_date", nullable = false)
+    private LocalDate weekStartDate;
+}

--- a/src/main/java/com/ll/playon/domain/guild/guild/projection/TopGuildPostProjection.java
+++ b/src/main/java/com/ll/playon/domain/guild/guild/projection/TopGuildPostProjection.java
@@ -1,0 +1,6 @@
+package com.ll.playon.domain.guild.guild.projection;
+
+public interface TopGuildPostProjection {
+    Long getGuildId();
+    Long getPostCount();
+}

--- a/src/main/java/com/ll/playon/domain/guild/guild/repository/GuildRepositoryImpl.java
+++ b/src/main/java/com/ll/playon/domain/guild/guild/repository/GuildRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.ll.playon.domain.guild.guild.dto.request.GetGuildListRequest;
 import com.ll.playon.domain.guild.guild.entity.Guild;
 import com.ll.playon.domain.guild.guild.entity.QGuild;
 import com.ll.playon.domain.guild.guild.entity.QGuildTag;
+import com.ll.playon.domain.guild.guildBoard.entity.QGuildBoard;
 import com.ll.playon.global.type.TagType;
 import com.ll.playon.global.type.TagValue;
 import com.querydsl.core.BooleanBuilder;
@@ -29,6 +30,7 @@ public class GuildRepositoryImpl implements GuildRepositoryCustom {
     public Page<Guild> searchGuilds(GetGuildListRequest req, Pageable pageable, String sort) {
         QGuild guild = QGuild.guild;
         QGuildTag guildTag = QGuildTag.guildTag;
+        QGuildBoard board = QGuildBoard.guildBoard;
 
         BooleanBuilder builder = new BooleanBuilder()
                 .and(guild.isDeleted.isFalse())  // 삭제된 길드 제외
@@ -68,14 +70,19 @@ public class GuildRepositoryImpl implements GuildRepositoryCustom {
             }
         }
 
+// 정렬 분기 처리
+        boolean isActivitySort = sort.equals("activity");
+
         List<Guild> content = queryFactory
-                .selectDistinct(guild)
+                .select(guild)
                 .from(guild)
                 .leftJoin(guild.guildTags, guildTag)
+                .leftJoin(guild.guildBoards, board)
                 .where(builder)
+                .groupBy(guild.id)
+                .orderBy(getSort(sort, guild, board))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .orderBy(getSort(sort, guild))
                 .fetch();
 
         long total = Optional.ofNullable(
@@ -90,12 +97,11 @@ public class GuildRepositoryImpl implements GuildRepositoryCustom {
         return new PageImpl<>(content, pageable, total);
     }
 
-    private OrderSpecifier<?>[] getSort(String sort, QGuild guild) {
+    private OrderSpecifier<?> getSort(String sort, QGuild guild, QGuildBoard board) {
         return switch (sort) {
-            // TODO: activity 활동 많은 순 구현 필요(일주일당 게시글 많은 순)
-            case "members" -> new OrderSpecifier[]{guild.maxMembers.desc()};
-//            case "activity" -> new OrderSpecifier[]{guild.id.desc()};
-            default -> new OrderSpecifier[]{guild.createdAt.desc()}; // 최신순 기본
+            case "members" -> guild.maxMembers.desc(); // 멤버 많은 순
+            case "activity" -> board.id.count().desc(); // 게시글 많은 순
+            default -> guild.createdAt.desc(); // 최신순
         };
     }
 }

--- a/src/main/java/com/ll/playon/domain/guild/guild/repository/GuildRepositoryImpl.java
+++ b/src/main/java/com/ll/playon/domain/guild/guild/repository/GuildRepositoryImpl.java
@@ -77,7 +77,7 @@ public class GuildRepositoryImpl implements GuildRepositoryCustom {
                 .select(guild)
                 .from(guild)
                 .leftJoin(guild.guildTags, guildTag)
-                .leftJoin(guild.guildBoards, board)
+                .leftJoin(guild.boards, board)
                 .where(builder)
                 .groupBy(guild.id)
                 .orderBy(getSort(sort, guild, board))

--- a/src/main/java/com/ll/playon/domain/guild/guild/repository/WeeklyPopularGuildRepository.java
+++ b/src/main/java/com/ll/playon/domain/guild/guild/repository/WeeklyPopularGuildRepository.java
@@ -1,0 +1,14 @@
+package com.ll.playon.domain.guild.guild.repository;
+
+import com.ll.playon.domain.guild.guild.entity.WeeklyPopularGuild;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface WeeklyPopularGuildRepository extends JpaRepository<WeeklyPopularGuild, Long> {
+    @Query("SELECT guildId FROM WeeklyPopularGuild WHERE weekStartDate = :week ORDER BY postCount DESC")
+    List<Long> findGuildIdsByWeek(@Param("week") LocalDate weekStartDate);
+}

--- a/src/main/java/com/ll/playon/domain/guild/guild/scheduler/GuildScheduler.java
+++ b/src/main/java/com/ll/playon/domain/guild/guild/scheduler/GuildScheduler.java
@@ -1,0 +1,45 @@
+package com.ll.playon.domain.guild.guild.scheduler;
+
+import com.ll.playon.domain.guild.guild.entity.WeeklyPopularGuild;
+import com.ll.playon.domain.guild.guild.repository.WeeklyPopularGuildRepository;
+import com.ll.playon.domain.guild.guildBoard.repository.GuildBoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class GuildScheduler {
+    final int limit = 3;
+    private final WeeklyPopularGuildRepository weeklyPopularGuildRepository;
+    private final GuildBoardRepository guildBoardRepository;
+
+//    @Scheduled(cron = "0 0 3 * * MON") // 매주 월요일 03:00
+    @Scheduled(cron = "0 * * * * *")
+    public void updateWeeklyGuildStats() {
+        LocalDate weekStart = LocalDate.now().with(DayOfWeek.MONDAY);
+        LocalDateTime fromDate = weekStart.minusWeeks(1).atStartOfDay(); // 지난주
+        LocalDateTime toDate = weekStart.atStartOfDay(); // 이번주
+
+        updatePopularGuild(fromDate, toDate, weekStart);
+    }
+
+    // 일주일간 커뮤니티 글 많은 길드
+    private void updatePopularGuild(LocalDateTime fromDate, LocalDateTime toDate, LocalDate weekStart) {
+        List<WeeklyPopularGuild> list = guildBoardRepository.findTopGuildsByPartyLastWeek(fromDate, toDate, PageRequest.of(0, limit))
+                .stream()
+                .map(row -> WeeklyPopularGuild.builder()
+                        .guildId(row.getGuildId())
+                        .postCount(row.getPostCount())
+                        .weekStartDate(weekStart)
+                        .build())
+                .toList();
+        weeklyPopularGuildRepository.saveAll(list);
+    }
+}

--- a/src/main/java/com/ll/playon/domain/guild/guildBoard/repository/GuildBoardRepository.java
+++ b/src/main/java/com/ll/playon/domain/guild/guildBoard/repository/GuildBoardRepository.java
@@ -1,6 +1,7 @@
 package com.ll.playon.domain.guild.guildBoard.repository;
 
 import com.ll.playon.domain.guild.guild.entity.Guild;
+import com.ll.playon.domain.guild.guild.projection.TopGuildPostProjection;
 import com.ll.playon.domain.guild.guildBoard.entity.GuildBoard;
 import com.ll.playon.domain.guild.guildBoard.enums.BoardTag;
 import com.ll.playon.domain.guild.guildMember.entity.GuildMember;
@@ -8,6 +9,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface GuildBoardRepository extends JpaRepository<GuildBoard, Long> {
     @EntityGraph(attributePaths = {"author.member"})
@@ -20,4 +26,19 @@ public interface GuildBoardRepository extends JpaRepository<GuildBoard, Long> {
     Page<GuildBoard> findByGuildAndTagAndTitleContaining(Guild guild, BoardTag tag, String keyword, Pageable pageable);
 
     int countByAuthor(GuildMember author);
+
+    @Query("""
+                SELECT gb.guild.id AS guildId, COUNT(gb) AS postCount
+                FROM GuildBoard gb
+                WHERE gb.createdAt >= :fromDate AND gb.createdAt < :toDate
+                  AND gb.guild.isDeleted = false
+                  AND gb.guild.isPublic = true
+                GROUP BY gb.guild.id
+                ORDER BY COUNT(gb) DESC
+            """)
+    List<TopGuildPostProjection> findTopGuildsByPartyLastWeek(
+            @Param("fromDate") LocalDateTime fromDate,
+            @Param("toDate") LocalDateTime toDate,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -5,7 +5,7 @@ import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.game.game.entity.SteamGenre;
 import com.ll.playon.domain.game.game.repository.GameRepository;
 import com.ll.playon.domain.game.game.service.GameService;
-import com.ll.playon.domain.game.scheduler.repository.WeeklyGameRepository;
+import com.ll.playon.domain.game.game.repository.WeeklyGameRepository;
 import com.ll.playon.domain.member.dto.GetMembersResponse;
 import com.ll.playon.domain.member.dto.MemberDetailDto;
 import com.ll.playon.domain.member.dto.MemberProfileResponse;

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -2,7 +2,7 @@ package com.ll.playon.global.initData;
 
 import com.ll.playon.domain.game.game.entity.*;
 import com.ll.playon.domain.game.game.repository.GameRepository;
-import com.ll.playon.domain.game.scheduler.repository.WeeklyGameRepository;
+import com.ll.playon.domain.game.game.repository.WeeklyGameRepository;
 import com.ll.playon.domain.guild.guild.entity.Guild;
 import com.ll.playon.domain.guild.guild.entity.GuildTag;
 import com.ll.playon.domain.guild.guild.repository.GuildRepository;


### PR DESCRIPTION
### 구현기능
- GuildScheduler를 통한 주간 인기 길드 집계 스케줄러 추가
    - 월요일 새벽 3시 진행
    - 주간 인기 길드 통계 테이블 (`weekly_popular_guild`) 생성
- 게시글 수 기반 활동 정렬 (`sort=activity`) 기능 추가
    - QueryDSL에서 Guild → GuildBoard 연관관계 기반 정렬 처리

