### PR TITLE
[FEAT] 채팅방 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,10 @@ dependencies {
     // RDS-MySQL
     implementation 'mysql:mysql-connector-java:8.0.33'
 
+    // WebSocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.webjars:sockjs-client:1.5.1'
+    implementation 'org.webjars:stomp-websocket:2.3.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ll/playon/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/ll/playon/domain/chat/controller/ChatController.java
@@ -1,0 +1,47 @@
+package com.ll.playon.domain.chat.controller;
+
+import com.ll.playon.domain.chat.dto.GetChatRoomResponse;
+import com.ll.playon.domain.chat.service.ChatService;
+import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.global.response.RsData;
+import com.ll.playon.global.security.UserContext;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+public class ChatController {
+    private final ChatService chatService;
+    private final UserContext userContext;
+
+    @PostMapping("/enter/{partyId}")
+    @Operation(summary = "채팅방 입장")
+    public RsData<GetChatRoomResponse> enterPartyRoom(@PathVariable long partyId,
+                                                      @RequestHeader("X-USER-ID") long userId) {
+        // TODO: 배포 시 주석 해제, @RequestHeader 삭제
+//        Member actor = this.userContext.getActor();
+        Member actor = this.userContext.findById(userId);
+
+        return RsData.success(HttpStatus.OK, this.chatService.enterPartyRoom(actor, partyId));
+    }
+
+    @PostMapping("/leave/{partyId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "채팅방 퇴장")
+    public void leavePartyRoom(@PathVariable long partyId,
+                               @RequestHeader("X-USER-ID") long userId) {
+        // TODO: 배포 시 주석 해제
+//        Member actor = this.userContext.getActor();
+        Member actor = this.userContext.findById(userId);
+
+        this.chatService.leavePartyRoom(actor, partyId);
+    }
+}

--- a/src/main/java/com/ll/playon/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/ll/playon/domain/chat/controller/ChatMessageController.java
@@ -1,0 +1,33 @@
+package com.ll.playon.domain.chat.controller;
+
+import com.ll.playon.domain.chat.dto.ChatMessageDto;
+import com.ll.playon.domain.chat.service.ChatMessageService;
+import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.global.webSocket.WebSocketUserContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatMessageController {
+    private final WebSocketUserContext webSocketUserContext;
+    private final ChatMessageService chatMessageService;
+
+    // TODO: 배포 시 주석 해제
+//    @MessageMapping("/chat.send/{partyId}")
+//    public void handleMessage(@DestinationVariable long partyId, @Payload String message, Principal principal) {
+//        Member sender = this.webSocketUserContext.getActor(principal);
+//
+//        this.chatMessageService.broadcastMessage(partyId, ChatMessageDto.of(sender, message));
+//    }
+
+    @MessageMapping("/chat.send/{partyId}/member/{memberId}")
+    public void handleMessage(@DestinationVariable long partyId, @DestinationVariable long memberId, @Payload String message) {
+        Member sender = this.webSocketUserContext.findById(memberId);
+
+        this.chatMessageService.broadcastMessage(partyId, ChatMessageDto.of(sender, message));
+    }
+}

--- a/src/main/java/com/ll/playon/domain/chat/dto/ChatMemberCountDto.java
+++ b/src/main/java/com/ll/playon/domain/chat/dto/ChatMemberCountDto.java
@@ -1,0 +1,7 @@
+package com.ll.playon.domain.chat.dto;
+
+public record ChatMemberCountDto(
+        long partyRoomId,
+        long remainCount
+) {
+}

--- a/src/main/java/com/ll/playon/domain/chat/dto/ChatMemberDto.java
+++ b/src/main/java/com/ll/playon/domain/chat/dto/ChatMemberDto.java
@@ -1,0 +1,23 @@
+package com.ll.playon.domain.chat.dto;
+
+import com.ll.playon.domain.chat.entity.ChatMember;
+import jakarta.validation.constraints.NotBlank;
+import lombok.NonNull;
+
+public record ChatMemberDto(
+        long memberId,
+
+        @NotBlank
+        String nickname,
+
+        @NonNull
+        String profileImg
+) {
+    public ChatMemberDto(ChatMember chatMember) {
+        this(
+                chatMember.getPartyMember().getMember().getId(),
+                chatMember.getPartyMember().getMember().getNickname(),
+                chatMember.getPartyMember().getMember().getProfileImg()
+        );
+    }
+}

--- a/src/main/java/com/ll/playon/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/ll/playon/domain/chat/dto/ChatMessageDto.java
@@ -1,0 +1,58 @@
+package com.ll.playon.domain.chat.dto;
+
+import com.ll.playon.domain.member.entity.Member;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import lombok.NonNull;
+
+public record ChatMessageDto(
+        long senderMemberId,
+
+        // TODO: 칭호 연동 후 주석 해제
+//        String title,
+
+        @NotBlank
+        String nickname,
+
+        @NonNull
+        String profileImg,
+
+        @NotBlank
+        String message,
+
+        @NonNull
+        LocalDateTime sendAt
+) {
+    public static ChatMessageDto of(Member member, String message) {
+        return new ChatMessageDto(
+                member.getId(),
+//                member.getTitle(),
+                member.getNickname(),
+                member.getProfileImg(),
+                message,
+                LocalDateTime.now()
+        );
+    }
+
+    public static ChatMessageDto enter(Member member) {
+        return new ChatMessageDto(
+                member.getId(),
+//                member.getTitle(),
+                member.getNickname(),
+                member.getProfileImg(),
+                "[" + member.getNickname() + " ]님이 입장하셨습니다.",
+                LocalDateTime.now()
+        );
+    }
+
+    public static ChatMessageDto leave(Member member) {
+        return new ChatMessageDto(
+                member.getId(),
+//                member.getTitle(),
+                member.getNickname(),
+                member.getProfileImg(),
+                "[" + member.getNickname() + " ]님이 퇴장하셨습니다.",
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/com/ll/playon/domain/chat/dto/GetChatRoomResponse.java
+++ b/src/main/java/com/ll/playon/domain/chat/dto/GetChatRoomResponse.java
@@ -1,0 +1,16 @@
+package com.ll.playon.domain.chat.dto;
+
+import java.util.List;
+import lombok.NonNull;
+
+public record GetChatRoomResponse(
+        long partyRoomId,
+        long partyId,
+
+        @NonNull
+        List<ChatMemberDto> members,
+
+        @NonNull
+        List<ChatMessageDto> messages
+) {
+}

--- a/src/main/java/com/ll/playon/domain/chat/entity/ChatMember.java
+++ b/src/main/java/com/ll/playon/domain/chat/entity/ChatMember.java
@@ -1,0 +1,38 @@
+package com.ll.playon.domain.chat.entity;
+
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class ChatMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private PartyRoom partyRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private PartyMember partyMember;
+
+    // 반드시 파티룸과 파티멤버가 존재해야 생성 가능
+    @Builder
+    public ChatMember(PartyRoom partyRoom, PartyMember partyMember) {
+        this.partyRoom = partyRoom;
+        this.partyMember = partyMember;
+    }
+}

--- a/src/main/java/com/ll/playon/domain/chat/entity/PartyRoom.java
+++ b/src/main/java/com/ll/playon/domain/chat/entity/PartyRoom.java
@@ -1,0 +1,41 @@
+package com.ll.playon.domain.chat.entity;
+
+import com.ll.playon.domain.party.party.entity.Party;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class PartyRoom {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Party party;
+
+    @CreatedDate
+    @Setter(AccessLevel.PRIVATE)
+    private LocalDateTime createdAt;
+
+    // 반드시 Party가 존재해야 생성 가능
+    @Builder
+    public PartyRoom(Party party) {
+        this.party = party;
+    }
+}

--- a/src/main/java/com/ll/playon/domain/chat/event/PartyRoomsDeleteEvent.java
+++ b/src/main/java/com/ll/playon/domain/chat/event/PartyRoomsDeleteEvent.java
@@ -1,0 +1,10 @@
+package com.ll.playon.domain.chat.event;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record PartyRoomsDeleteEvent(
+        @NotNull
+        List<Long> candidateIds
+) {
+}

--- a/src/main/java/com/ll/playon/domain/chat/listener/PartyRoomEventListener.java
+++ b/src/main/java/com/ll/playon/domain/chat/listener/PartyRoomEventListener.java
@@ -1,0 +1,56 @@
+package com.ll.playon.domain.chat.listener;
+
+import com.ll.playon.domain.chat.dto.ChatMemberCountDto;
+import com.ll.playon.domain.chat.event.PartyRoomsDeleteEvent;
+import com.ll.playon.domain.chat.policy.PartyRoomDeletePolicy;
+import com.ll.playon.domain.chat.repository.ChatMemberRepository;
+import com.ll.playon.domain.chat.repository.PartyRoomRepository;
+import com.ll.playon.global.exceptions.ErrorCode;
+import com.ll.playon.global.exceptions.EventListenerException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class PartyRoomEventListener {
+    private final ChatMemberRepository chatMemberRepository;
+    private final PartyRoomRepository partyRoomRepository;
+
+    @EventListener
+    public void deletePartyRooms(PartyRoomsDeleteEvent event) {
+        int successCount = 0;
+        List<Long> failedIds = new ArrayList<>();
+
+        List<Long> candidateIds = event.candidateIds();
+
+        Map<Long, Long> remainCountMap = this.chatMemberRepository.countByPartyRoomIds(candidateIds).stream()
+                .collect(Collectors.toMap(ChatMemberCountDto::partyRoomId, ChatMemberCountDto::remainCount));
+
+        for (Long partyRoomId : candidateIds) {
+            Long remainCount = remainCountMap.getOrDefault(partyRoomId, 0L);
+
+            try {
+                if (PartyRoomDeletePolicy.shouldDeletePartyRoom(remainCount)) {
+                    this.partyRoomRepository.deleteById(partyRoomId);
+                    successCount++;
+                }
+            } catch (Exception ex) {
+                failedIds.add(partyRoomId);
+                log.error("id={}번 파티룸 삭제 실패", partyRoomId, ex);
+            }
+        }
+
+        if (successCount == 0) {
+            throw new EventListenerException(ErrorCode.PARTY_ROOM_DELETE_FAILED);
+        }
+
+        log.info("삭제된 파티룸: {}개, 삭제 실패: {}개, 실패 파티룸ID: {}", successCount, failedIds.size(), failedIds);
+    }
+}

--- a/src/main/java/com/ll/playon/domain/chat/mapper/ChatMemberMapper.java
+++ b/src/main/java/com/ll/playon/domain/chat/mapper/ChatMemberMapper.java
@@ -1,0 +1,14 @@
+package com.ll.playon.domain.chat.mapper;
+
+import com.ll.playon.domain.chat.entity.ChatMember;
+import com.ll.playon.domain.chat.entity.PartyRoom;
+import com.ll.playon.domain.party.party.entity.PartyMember;
+
+public class ChatMemberMapper {
+    public static ChatMember of(PartyRoom partyRoom, PartyMember partyMember) {
+        return ChatMember.builder()
+                .partyRoom(partyRoom)
+                .partyMember(partyMember)
+                .build();
+    }
+}

--- a/src/main/java/com/ll/playon/domain/chat/mapper/PartyRoomMapper.java
+++ b/src/main/java/com/ll/playon/domain/chat/mapper/PartyRoomMapper.java
@@ -1,0 +1,12 @@
+package com.ll.playon.domain.chat.mapper;
+
+import com.ll.playon.domain.chat.entity.PartyRoom;
+import com.ll.playon.domain.party.party.entity.Party;
+
+public class PartyRoomMapper {
+    public static PartyRoom of(Party party) {
+        return PartyRoom.builder()
+                .party(party)
+                .build();
+    }
+}

--- a/src/main/java/com/ll/playon/domain/chat/policy/PartyRoomDeletePolicy.java
+++ b/src/main/java/com/ll/playon/domain/chat/policy/PartyRoomDeletePolicy.java
@@ -1,0 +1,18 @@
+package com.ll.playon.domain.chat.policy;
+
+import com.ll.playon.domain.party.party.entity.Party;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PartyRoomDeletePolicy {
+    public static boolean shouldDeletePartyRoom(long count, Party party) {
+        return count == 0 && party.getPartyAt().plusMinutes(5).isBefore(LocalDateTime.now());
+    }
+
+    public static boolean shouldDeletePartyRoom(long count) {
+        return count == 0;
+    }
+}

--- a/src/main/java/com/ll/playon/domain/chat/repository/ChatMemberRepository.java
+++ b/src/main/java/com/ll/playon/domain/chat/repository/ChatMemberRepository.java
@@ -1,0 +1,29 @@
+package com.ll.playon.domain.chat.repository;
+
+import com.ll.playon.domain.chat.dto.ChatMemberCountDto;
+import com.ll.playon.domain.chat.entity.ChatMember;
+import com.ll.playon.domain.chat.entity.PartyRoom;
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ChatMemberRepository extends JpaRepository<ChatMember, Long> {
+    Boolean existsByPartyRoomAndPartyMember(PartyRoom partyRoom, PartyMember partyMember);
+
+    List<ChatMember> findAllByPartyRoom(PartyRoom partyRoom);
+
+    Optional<ChatMember> findByPartyRoomAndPartyMember(PartyRoom partyRoom, PartyMember partyMember);
+
+    Long countByPartyRoom(PartyRoom partyRoom);
+
+    @Query("""
+            SELECT new com.ll.playon.domain.chat.dto.ChatMemberCountDto(cm.partyRoom.id, COUNT(cm))
+            FROM ChatMember cm
+            WHERE cm.partyRoom.id IN :partyRoomIds
+            GROUP BY cm.partyRoom.id
+            """)
+    List<ChatMemberCountDto> countByPartyRoomIds(@Param("candidateIds") List<Long> candidateIds);
+}

--- a/src/main/java/com/ll/playon/domain/chat/repository/PartyRoomRepository.java
+++ b/src/main/java/com/ll/playon/domain/chat/repository/PartyRoomRepository.java
@@ -1,0 +1,22 @@
+package com.ll.playon.domain.chat.repository;
+
+import com.ll.playon.domain.chat.entity.PartyRoom;
+import com.ll.playon.domain.party.party.entity.Party;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PartyRoomRepository extends JpaRepository<PartyRoom, Long> {
+    Optional<PartyRoom> findByParty(Party party);
+
+    @Query("""
+            SELECT pr.id
+            from PartyRoom pr
+            JOIN pr.party p
+            WHERE p.partyAt <= :deadlineTime
+            """)
+    List<Long> findDeletablePartyRooms(@Param("deadlineTime") LocalDateTime deadlineTime);
+}

--- a/src/main/java/com/ll/playon/domain/chat/scheduled/DeletePartyRoomsScheduler.java
+++ b/src/main/java/com/ll/playon/domain/chat/scheduled/DeletePartyRoomsScheduler.java
@@ -1,0 +1,27 @@
+package com.ll.playon.domain.chat.scheduled;
+
+import com.ll.playon.domain.chat.event.PartyRoomsDeleteEvent;
+import com.ll.playon.domain.chat.repository.PartyRoomRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeletePartyRoomsScheduler {
+    private final PartyRoomRepository partyRoomRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    // TODO: 배포환경에서 주석 해제
+//    @Scheduled(fixedDelay = 1000 * 60 * 10)
+    public void deleteUnusedPartyRooms() {
+        LocalDateTime deadlineTime = LocalDateTime.now().minusMinutes(5);
+        List<Long> candidates = this.partyRoomRepository.findDeletablePartyRooms(deadlineTime);
+
+        if (!candidates.isEmpty()) {
+            this.eventPublisher.publishEvent(new PartyRoomsDeleteEvent(candidates));
+        }
+    }
+}

--- a/src/main/java/com/ll/playon/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/ll/playon/domain/chat/service/ChatMessageService.java
@@ -1,0 +1,22 @@
+package com.ll.playon.domain.chat.service;
+
+import com.ll.playon.domain.chat.dto.ChatMemberDto;
+import com.ll.playon.domain.chat.dto.ChatMessageDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+    private final SimpMessageSendingOperations messagingTemplate;
+
+    public void broadcastMessage(long partyId, ChatMessageDto chatMessageDto) {
+        this.messagingTemplate.convertAndSend("/topic/chat/party/" + partyId, chatMessageDto);
+    }
+
+    public void broadcastMemberList(long partyId, List<ChatMemberDto> chatMembers) {
+        this.messagingTemplate.convertAndSend("/topic/chat/party/" + partyId + "/members", chatMembers);
+    }
+}

--- a/src/main/java/com/ll/playon/domain/chat/service/ChatService.java
+++ b/src/main/java/com/ll/playon/domain/chat/service/ChatService.java
@@ -1,0 +1,100 @@
+package com.ll.playon.domain.chat.service;
+
+import com.ll.playon.domain.chat.dto.ChatMemberDto;
+import com.ll.playon.domain.chat.dto.ChatMessageDto;
+import com.ll.playon.domain.chat.dto.GetChatRoomResponse;
+import com.ll.playon.domain.chat.entity.ChatMember;
+import com.ll.playon.domain.chat.entity.PartyRoom;
+import com.ll.playon.domain.chat.mapper.ChatMemberMapper;
+import com.ll.playon.domain.chat.policy.PartyRoomDeletePolicy;
+import com.ll.playon.domain.chat.repository.ChatMemberRepository;
+import com.ll.playon.domain.chat.repository.PartyRoomRepository;
+import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.party.party.context.PartyContext;
+import com.ll.playon.domain.party.party.context.PartyMemberContext;
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.global.annotation.ActivePartyMemberOnly;
+import com.ll.playon.global.exceptions.ErrorCode;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+    private final ChatMessageService chatMessageService;
+    private final ChatMemberRepository chatMemberRepository;
+    private final PartyRoomRepository partyRoomRepository;
+
+    // 채팅방 입장
+    @ActivePartyMemberOnly
+    @Transactional
+    public GetChatRoomResponse enterPartyRoom(Member actor, Long partyId) {
+        Party party = PartyContext.getParty();
+        PartyMember partymember = PartyMemberContext.getPartyMember();
+        PartyRoom partyRoom = this.getPartyRoom(party);
+
+        // 중복 참여 제한
+        boolean isAlreadyEntered = this.chatMemberRepository.existsByPartyRoomAndPartyMember(partyRoom, partymember);
+        if (isAlreadyEntered) {
+            ErrorCode.IS_ALREADY_CHAT_MEMBER.throwServiceException();
+        }
+
+        this.chatMemberRepository.save(ChatMemberMapper.of(partyRoom, partymember));
+
+        this.chatMessageService.broadcastMessage(partyId, ChatMessageDto.enter(actor));
+
+        List<ChatMemberDto> chatMemberDtos = this.getChatMemberDtos(partyRoom);
+
+        this.chatMessageService.broadcastMemberList(partyId, chatMemberDtos);
+
+        return new GetChatRoomResponse(
+                partyRoom.getId(),
+                partyId,
+                chatMemberDtos,
+                Collections.emptyList()
+        );
+    }
+
+    // 채팅방 퇴장
+    @ActivePartyMemberOnly
+    @Transactional
+    public void leavePartyRoom(Member actor, long partyId) {
+        Party party = PartyContext.getParty();
+        PartyMember partyMember = PartyMemberContext.getPartyMember();
+        PartyRoom partyRoom = this.getPartyRoom(party);
+
+        ChatMember chatMember = this.chatMemberRepository.findByPartyRoomAndPartyMember(partyRoom, partyMember)
+                .orElseThrow(ErrorCode.CHAT_MEMBER_NOT_FOUND::throwServiceException);
+
+        this.chatMemberRepository.delete(chatMember);
+
+        long remainCount = this.chatMemberRepository.countByPartyRoom(partyRoom);
+
+        // 파티 진행 시간 5분 이상 지나고, 채팅인원이 0명이면 채팅방 삭제, 브로드캐스트 생략
+        if (PartyRoomDeletePolicy.shouldDeletePartyRoom(remainCount, party)) {
+            this.partyRoomRepository.delete(partyRoom);
+            return;
+        }
+
+        this.chatMessageService.broadcastMessage(partyId, ChatMessageDto.leave(actor));
+
+        this.chatMessageService.broadcastMemberList(partyId, this.getChatMemberDtos(partyRoom));
+    }
+
+    // Party로 PartyRoom 조회
+    private PartyRoom getPartyRoom(Party party) {
+        return this.partyRoomRepository.findByParty(party)
+                .orElseThrow(ErrorCode.PARTY_ROOM_NOT_FOUND::throwServiceException);
+    }
+
+    // PartyRoom으로 채팅방 참여 멤버(DTO) 리스트 조회
+    private List<ChatMemberDto> getChatMemberDtos(PartyRoom partyRoom) {
+        return this.chatMemberRepository.findAllByPartyRoom(partyRoom).stream()
+                .map(ChatMemberDto::new)
+                .toList();
+    }
+}

--- a/src/main/java/com/ll/playon/domain/image/event/ImageDeleteEvent.java
+++ b/src/main/java/com/ll/playon/domain/image/event/ImageDeleteEvent.java
@@ -1,0 +1,6 @@
+package com.ll.playon.domain.image.event;
+
+public record ImageDeleteEvent(
+        long id
+) {
+}

--- a/src/main/java/com/ll/playon/domain/image/listener/ImageEventListener.java
+++ b/src/main/java/com/ll/playon/domain/image/listener/ImageEventListener.java
@@ -1,10 +1,11 @@
-package com.ll.playon.domain.party.partyLog.listener;
+package com.ll.playon.domain.image.listener;
 
+import com.ll.playon.domain.image.event.ImageDeleteEvent;
 import com.ll.playon.domain.image.service.ImageService;
 import com.ll.playon.domain.image.type.ImageType;
-import com.ll.playon.domain.party.partyLog.event.ImageDeleteEvent;
 import com.ll.playon.global.exceptions.ErrorCode;
 import com.ll.playon.global.exceptions.EventListenerException;
+import com.ll.playon.global.exceptions.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.retry.annotation.Backoff;
@@ -26,12 +27,13 @@ public class ImageEventListener {
     )
     public void handleImageDelete(ImageDeleteEvent event) {
         try {
-            this.imageService.deleteImageById(ImageType.LOG, event.logId());
-            throw new RuntimeException("이벤트 리스너 에러 테스트");
-        } catch (Exception ex) {
+            this.imageService.deleteImageById(ImageType.LOG, event.id());
+        } catch (ServiceException ex) {
             // TODO: 이벤트 실패 시 알람?
             // TODO: 실패한 S3 삭제(처리) 방법 고안
 
+            throw new EventListenerException(ex.getResultCode(), ex.getMsg());
+        } catch (Exception e) {
             throw new EventListenerException(ErrorCode.EVENT_LISTENER_ERROR);
         }
     }

--- a/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
+++ b/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
@@ -46,7 +46,7 @@ public class PartyController {
     public RsData<PostPartyResponse> createParty(@RequestBody @Valid PostPartyRequest postPartyRequest) {
         // TODO : 추후 롤백
 //        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(6L);
+        Member actor = this.userContext.findById(5L);
 
         return RsData.success(HttpStatus.CREATED, this.partyService.createParty(actor, postPartyRequest));
     }

--- a/src/main/java/com/ll/playon/domain/party/party/dto/request/PostPartyRequest.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/request/PostPartyRequest.java
@@ -26,7 +26,6 @@ public record PostPartyRequest(
         @NotNull(message = "최대 인원을 입력해주세요.") @Max(value = 50, message = "최대 인원은 50명까지 가능합니다.")
         Integer maximum,
 
-        // TODO : Game 엔티티 개설되면 변경
         @NotNull
         Long gameId,
 

--- a/src/main/java/com/ll/playon/domain/party/party/dto/response/GetCompletedPartyDto.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/response/GetCompletedPartyDto.java
@@ -16,6 +16,9 @@ public record GetCompletedPartyDto(
         @NotBlank
         String name,
 
+        @NotBlank
+        String gameName,
+
         @NonNull
         String mvpName,
 
@@ -33,9 +36,6 @@ public record GetCompletedPartyDto(
 
         @NonNull
         List<PartyDetailTagDto> partyTags
-
-        // TODO: 1. 스팀 헤더 사진 추가
-        //       2. 채팅 룸 여기에?
 ) {
     public GetCompletedPartyDto(Party party, PartyMember mvp, TotalPlayTimeDto playTime,
                                 List<PartyDetailMemberDto> partyMembers,
@@ -43,6 +43,7 @@ public record GetCompletedPartyDto(
         this(
                 party.getId(),
                 party.getName(),
+                party.getGame().getName(),
                 mvp.getMember().getNickname(),
                 mvp.getMember().getProfileImg(),
                 party.getPartyAt(),

--- a/src/main/java/com/ll/playon/domain/party/party/dto/response/GetPartyResponse.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/response/GetPartyResponse.java
@@ -33,8 +33,7 @@ public record GetPartyResponse(
         @NonNull
         List<PartyDetailTagDto> partyTags
 
-        // TODO: 1. 스팀 게임 헤더 이미지
-        //       2. 스팀 아바타로 변경할지 고려
+        // TODO: 스팀 아바타로 변경할지 고려
 ) {
     public GetPartyResponse(Party party, List<PartyTag> tagDtos, List<PartyMember> memberDtos) {
         this(

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -21,7 +21,6 @@ import com.ll.playon.domain.party.party.dto.response.GetPartyResponse;
 import com.ll.playon.domain.party.party.dto.response.GetPartyResultResponse;
 import com.ll.playon.domain.party.party.dto.response.PostPartyResponse;
 import com.ll.playon.domain.party.party.dto.response.PutPartyResponse;
-import com.ll.playon.domain.party.party.dto.response.*;
 import com.ll.playon.domain.party.party.entity.Party;
 import com.ll.playon.domain.party.party.entity.PartyMember;
 import com.ll.playon.domain.party.party.entity.PartyTag;
@@ -33,11 +32,11 @@ import com.ll.playon.domain.party.party.type.PartyRole;
 import com.ll.playon.domain.party.party.type.PartyStatus;
 import com.ll.playon.domain.party.party.util.PartySortUtils;
 import com.ll.playon.domain.party.party.validation.PartyMemberValidation;
-import com.ll.playon.domain.title.entity.enums.ConditionType;
-import com.ll.playon.domain.title.service.TitleEvaluator;
 import com.ll.playon.domain.party.party.validation.PartyValidation;
 import com.ll.playon.domain.party.partyLog.dto.response.GetAllPartyLogResponse;
 import com.ll.playon.domain.party.partyLog.service.PartyLogService;
+import com.ll.playon.domain.title.entity.enums.ConditionType;
+import com.ll.playon.domain.title.service.TitleEvaluator;
 import com.ll.playon.global.annotation.PartyOwnerOnly;
 import com.ll.playon.global.exceptions.ErrorCode;
 import com.ll.playon.global.type.TagValue;
@@ -59,10 +58,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.*;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -91,10 +86,12 @@ public class PartyService {
         PartyRoom partyRoom = PartyRoomMapper.of(party);
         this.partyRoomRepository.save(partyRoom);
 
+        this.partyRepository.save(party);
+
         // 파티 생성 칭호
         titleEvaluator.check(ConditionType.PARTY_CREATE_COUNT, actor);
 
-        return new PostPartyResponse(this.partyRepository.save(party));
+        return new PostPartyResponse(party);
     }
 
     // 파티 검색 및 조회 (조건 반영)

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -1,5 +1,8 @@
 package com.ll.playon.domain.party.party.service;
 
+import com.ll.playon.domain.chat.entity.PartyRoom;
+import com.ll.playon.domain.chat.mapper.PartyRoomMapper;
+import com.ll.playon.domain.chat.repository.PartyRoomRepository;
 import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.game.game.repository.GameRepository;
 import com.ll.playon.domain.member.entity.Member;
@@ -68,6 +71,7 @@ public class PartyService {
     private final PartyLogService partyLogService;
     private final MemberService memberService;
     private final PartyRepository partyRepository;
+    private final PartyRoomRepository partyRoomRepository;
     private final GameRepository gameRepository;
     private final TitleEvaluator titleEvaluator;
 
@@ -84,8 +88,8 @@ public class PartyService {
 
         party.addPartyMember(PartyMemberMapper.of(actor, PartyRole.OWNER));
 
-        // TODO: 1. Game 헤더 이미지 응답
-        //       2. 파티룸 생성
+        PartyRoom partyRoom = PartyRoomMapper.of(party);
+        this.partyRoomRepository.save(partyRoom);
 
         // 파티 생성 칭호
         titleEvaluator.check(ConditionType.PARTY_CREATE_COUNT, actor);

--- a/src/main/java/com/ll/playon/domain/party/partyLog/event/ImageDeleteEvent.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/event/ImageDeleteEvent.java
@@ -1,6 +1,0 @@
-package com.ll.playon.domain.party.partyLog.event;
-
-public record ImageDeleteEvent(
-        long logId
-) {
-}

--- a/src/main/java/com/ll/playon/domain/party/partyLog/service/PartyLogService.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/service/PartyLogService.java
@@ -16,7 +16,7 @@ import com.ll.playon.domain.party.partyLog.dto.response.GetAllPartyLogResponse;
 import com.ll.playon.domain.party.partyLog.dto.response.GetPartyLogResponse;
 import com.ll.playon.domain.party.partyLog.dto.response.PartyLogResponse;
 import com.ll.playon.domain.party.partyLog.entity.PartyLog;
-import com.ll.playon.domain.party.partyLog.event.ImageDeleteEvent;
+import com.ll.playon.domain.image.event.ImageDeleteEvent;
 import com.ll.playon.domain.party.partyLog.mapper.PartyLogMapper;
 import com.ll.playon.domain.party.partyLog.repository.PartyLogRepository;
 import com.ll.playon.domain.party.partyLog.validation.PartyLogValidation;
@@ -156,7 +156,7 @@ public class PartyLogService {
 
         partyLog.delete();
 
-        eventPublisher.publishEvent(new ImageDeleteEvent(logId));
+        this.eventPublisher.publishEvent(new ImageDeleteEvent(logId));
     }
 
     // logId로 PartyLog 조회

--- a/src/main/java/com/ll/playon/domain/title/service/TitleEvaluator.java
+++ b/src/main/java/com/ll/playon/domain/title/service/TitleEvaluator.java
@@ -20,14 +20,17 @@ public class TitleEvaluator {
     private final MemberTitleService memberTitleService;
     private final MemberStatRepository memberStatRepository;
 
+    @Transactional
     public void check(ConditionType conditionType, Member member) {
         checkLogic(conditionType, member, 1);
     }
+
+    @Transactional
     public void gameCountCheck(ConditionType conditionType, Member member, int count) {
         checkLogic(conditionType, member, count);
     }
-    @Transactional
-    public void checkLogic(ConditionType conditionType, Member member, int count) {
+
+    private void checkLogic(ConditionType conditionType, Member member, int count) {
         // 해당 타입의 칭호 조회 (필요값으로 오름차순 정렬)
         final List<Title> titleList = titleService.findByConditionTypeOrderByConditionValueAsc(conditionType);
 

--- a/src/main/java/com/ll/playon/global/config/WebConfig.java
+++ b/src/main/java/com/ll/playon/global/config/WebConfig.java
@@ -2,9 +2,20 @@ package com.ll.playon.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @EnableSpringDataWebSupport
-public class WebConfig {
+public class WebConfig implements WebMvcConfigurer {
+    // 임시
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
 }
 

--- a/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
@@ -85,6 +85,14 @@ public enum ErrorCode {
     PARTY_OWNER_NOT_FOUND(HttpStatus.NOT_FOUND, "파티장이 존재하지 않습니다."),
     PENDING_PARTY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "파티 참가를 신청한 사용자가 아닙니다."),
 
+    // PartyRoom
+    PARTY_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "파티 채팅방이 존재하지 않습니다."),
+    PARTY_ROOM_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파티 채팅방 제거에 문제가 생겨 모든 채팅방 제거가 불가능합니다."),
+
+    // ChatMember
+    IS_ALREADY_CHAT_MEMBER(HttpStatus.FORBIDDEN, "이미 해당 채팅방에 참여중입니다"),
+    CHAT_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅 멤버가 존재하지 않습니다."),
+
     // PartyLog
     PARTY_LOG_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 파티 로그를 작성하셨습니다."),
     PARTY_IS_NOT_ENDED(HttpStatus.BAD_REQUEST, "파티가 종료되지 않았습니다."),

--- a/src/main/java/com/ll/playon/global/exceptions/EventListenerException.java
+++ b/src/main/java/com/ll/playon/global/exceptions/EventListenerException.java
@@ -13,4 +13,10 @@ public class EventListenerException extends RuntimeException {
         this.resultCode = errorCode.getHttpStatus();
         this.msg = errorCode.getMessage();
     }
+
+    public EventListenerException(HttpStatus resultCode, String msg) {
+        super(msg);
+        this.resultCode = resultCode;
+        this.msg = msg;
+    }
 }

--- a/src/main/java/com/ll/playon/global/webSocket/WebSocketUserContext.java
+++ b/src/main/java/com/ll/playon/global/webSocket/WebSocketUserContext.java
@@ -1,0 +1,28 @@
+package com.ll.playon.global.webSocket;
+
+import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.member.service.MemberService;
+import com.ll.playon.global.exceptions.ErrorCode;
+import java.security.Principal;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WebSocketUserContext {
+    private final MemberService memberService;
+
+    public Member getActor(Principal principal) {
+        return Optional.ofNullable(principal)
+                .map(Principal::getName)
+                .map(Long::parseLong)
+                .flatMap(memberService::findById)
+                .orElseThrow(ErrorCode.USER_NOT_REGISTERED::throwServiceException);
+    }
+
+    public Member findById(Long id) {
+        return this.memberService.findById(id)
+                .orElseThrow(ErrorCode.USER_NOT_REGISTERED::throwServiceException);
+    }
+}

--- a/src/main/java/com/ll/playon/global/webSocket/config/WebSocketConfig.java
+++ b/src/main/java/com/ll/playon/global/webSocket/config/WebSocketConfig.java
@@ -1,0 +1,38 @@
+package com.ll.playon.global.webSocket.config;
+
+import com.ll.playon.global.webSocket.security.JwtHandshakeInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws") // 프론트의 WebSocket 연결 주소
+//                .setAllowedOrigins("*")
+                .setAllowedOriginPatterns("*")
+//                .addInterceptors(jwtHandshakeInterceptor)
+                .withSockJS();  // SockJs Fallback
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");  // 서버 -> 클라이언트 (브로드캐스트 용도)
+        registry.setApplicationDestinationPrefixes("/app"); // 클라이언트 -> 서버 (메시지 브로드캐스트 요망)
+    }
+
+    @Override
+    public void configureWebSocketTransport(WebSocketTransportRegistration registration) {
+        registration.setMessageSizeLimit(64 * 1024);
+        registration.setSendBufferSizeLimit(512 * 1024);
+    }
+}

--- a/src/main/java/com/ll/playon/global/webSocket/security/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/ll/playon/global/webSocket/security/JwtHandshakeInterceptor.java
@@ -1,0 +1,85 @@
+package com.ll.playon.global.webSocket.security;
+
+import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.member.service.AuthTokenService;
+import com.ll.playon.domain.member.service.MemberService;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtHandshakeInterceptor implements HandshakeInterceptor {
+    private final AuthTokenService authTokenService;
+    private final MemberService memberService;  // TODO: 배포 환경에서 삭제
+
+    // TODO: 배포 환경에서 주석 해제 및 아래 메서드 삭제
+//    @Override
+//    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler,
+//                                   Map<String, Object> attributes) throws Exception {
+//        String token = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+//
+//        if (token.startsWith("Bearer ")) {
+//            token = token.substring("Bearer ".length());
+//
+//            Map<String, Object> payload = this.authTokenService.payload(token);
+//
+//            if (payload != null) {
+//                Long userId = (Long) payload.get("id");
+//                attributes.put("userId", userId);
+//                return true;
+//            }
+//        }
+//
+//        // 인증 실패 시 -> WebSocket 연결 거부
+//        return false;
+//    }
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+
+        // X-USER-ID 헤더에서 사용자 ID 추출
+        String userIdHeader = request.getHeaders().getFirst("X-USER-ID");
+
+        if (userIdHeader != null) {
+            try {
+                Long userId = Long.parseLong(userIdHeader);
+                Member user = memberService.findById(userId).get();
+
+                if (user != null) {
+                    // WebSocket 세션에 userId 저장
+                    attributes.put("userId", userId);
+
+                    // 임시로 Spring Security Context에 사용자 정보 설정 (테스트용)
+                    Authentication authentication = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                    return true;  // 인증 성공
+                }
+            } catch (NumberFormatException e) {
+                // X-USER-ID가 잘못된 값이라면 연결 거부
+                response.setStatusCode(HttpStatus.FORBIDDEN);  // 403 Forbidden
+                return false;
+            }
+        }
+
+        // X-USER-ID 헤더가 없다면 연결 거부
+        response.setStatusCode(HttpStatus.FORBIDDEN);  // 403 Forbidden
+        return false;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler,
+                               Exception exception) {
+
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,9 +2,11 @@
 <configuration>
     <!-- 로그 파일 기본 경로 및 이름 -->
     <property name="LOG_DIR" value="./logs/"/>
+    <property name="PARTY_DELETE_LOG_DIR" value="./logs/event/party/delete"/>
     <property name="LOG_FILE_NAME" value="info/info"/>
     <property name="ERROR_LOG_FILE_NAME" value="error/error"/>
-    <property name="SQL_LOG_FILE_NAME" value="sql/sql"/>
+    <property name="PARTY_DELETE_INFO_LOG_FILE" value="${PARTY_DELETE_LOG_DIR}/info"/>
+    <property name="PARTY_DELETE_ERROR_LOG_FILE" value="${PARTY_DELETE_LOG_DIR}/error"/>
 
     <!-- 콘솔 출력 Appender -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -51,6 +53,42 @@
                 <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
             </encoder>
         </appender>
+
+        <!-- Party Delete INFO 로그 -->
+        <appender name="PARTY_DELETE_INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${PARTY_DELETE_INFO_LOG_FILE}.log</file>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>ERROR</level>
+                <onMatch>DENY</onMatch>
+                <onMismatch>ACCEPT</onMismatch>
+            </filter>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>${PARTY_DELETE_INFO_LOG_FILE}-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                <maxFileSize>10MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+
+        <!-- Party Delete ERROR 로그 -->
+        <appender name="PARTY_DELETE_ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${PARTY_DELETE_ERROR_LOG_FILE}.log</file>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>ERROR</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>${PARTY_DELETE_ERROR_LOG_FILE}-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                <maxFileSize>10MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
     </springProfile>
 
     <!-- INFO, ERROR 로거 -->
@@ -58,6 +96,13 @@
     <logger name="com.ll.playon.global.aspect" level="INFO" additivity="false">
         <appender-ref ref="LOG_FILE"/>
         <appender-ref ref="ERROR_LOG_FILE"/>
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <!-- 파티 삭제 이벤트 관련 로거 -->
+    <logger name="com.ll.playon.domain.chat.listener.PartyRoomsDeleteEventListener" level="INFO" additivity="false">
+        <appender-ref ref="PARTY_DELETE_INFO_FILE"/>
+        <appender-ref ref="PARTY_DELETE_ERROR_FILE"/>
         <appender-ref ref="CONSOLE"/>
     </logger>
 

--- a/src/main/resources/static/chat-test.html
+++ b/src/main/resources/static/chat-test.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>STOMP Chat 테스트 클라이언트</title>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+        }
+
+        input, button {
+            margin: 5px;
+        }
+
+        #messages {
+            margin-top: 20px;
+            border: 1px solid #ccc;
+            padding: 10px;
+            height: 300px;
+            overflow-y: auto;
+            background: #f9f9f9;
+        }
+    </style>
+</head>
+<body>
+<h2>STOMP Chat 테스트 클라이언트</h2>
+
+<label>파티 ID: <input type="number" id="partyId" value="1"/></label><br/>
+<label>사용자 ID: <input type="number" id="userId" value="5"/></label><br/>
+
+<button onclick="enterAndConnect()">입장 + 연결</button>
+<button onclick="disconnect()">연결 해제</button>
+<br/>
+
+<label>메시지: <input type="text" id="messageInput"/></label>
+<button onclick="sendMessage()">보내기</button>
+
+<div id="messages"></div>
+
+<script>
+    let stompClient = null;
+    let userId = null; // 사용자 ID를 전역 변수로 선언
+
+    function enterAndConnect() {
+        const partyId = document.getElementById("partyId").value;
+        userId = document.getElementById("userId").value;  // 사용자 ID를 전역 변수에 할당
+
+        fetch(`http://localhost:8080/api/chat/enter/${partyId}`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-USER-ID": userId   // 👉 백엔드에서 사용 시 커스텀 헤더로 처리 가능
+            }
+        })
+            .then(res => res.json())
+            .then(data => {
+                log("✅ 입장 성공: " + JSON.stringify(data));
+                connectStomp(partyId);
+            })
+            .catch(err => {
+                log("❌ 입장 실패: " + err);
+            });
+    }
+
+    function connectStomp(partyId) {
+        const socket = new SockJS("http://localhost:8080/ws");  // WebSocket URL
+        stompClient = Stomp.over(socket);
+
+        stompClient.connect({}, function (frame) {
+            log("🟢 STOMP 연결됨");
+
+            // STOMP 구독
+            stompClient.subscribe(`/topic/chat/party/${partyId}`, function (msg) {
+                log("📥 메시지: " + msg.body);
+            });
+
+            stompClient.subscribe(`/topic/chat/party/${partyId}/members`, function (msg) {
+                log("👥 멤버 갱신: " + msg.body);
+            });
+
+            // 사용자 ID를 헤더에 추가하여 사용자 맞는 권한으로 구독할 수 있도록 설정
+            stompClient.send(`/app/chat.join/${partyId}`, {}, JSON.stringify({ userId: userId }));
+
+        }, function (error) {
+            log("❌ STOMP 연결 실패: " + error);
+        });
+    }
+
+    function disconnect() {
+        const partyId = document.getElementById("partyId").value;
+
+        // 먼저 퇴장 요청
+        fetch(`http://localhost:8080/api/chat/leave/${partyId}`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-USER-ID": userId
+            }
+        })
+            .then(res => {
+                if (!res.ok) throw new Error("퇴장 실패");
+                log("🚪 퇴장 요청 완료");
+            })
+            .catch(err => {
+                log("❌ 퇴장 요청 실패: " + err);
+            })
+            .finally(() => {
+                // STOMP 연결 해제
+                if (stompClient) {
+                    stompClient.disconnect(() => {
+                        log("🔴 STOMP 연결 해제됨");
+                    });
+                }
+            });
+    }
+
+    function sendMessage() {
+        const partyId = document.getElementById("partyId").value;
+        const message = document.getElementById("messageInput").value;
+
+        if (!stompClient || !stompClient.connected) {
+            log("❌ STOMP 연결이 안 됨! 메시지를 보낼 수 없음.");
+            return;
+        }
+
+        stompClient.send(`/app/chat.send/${partyId}`, {}, message);
+        log("📤 보낸 메시지: " + message);
+    }
+
+    function log(message) {
+        const messagesDiv = document.getElementById("messages");
+        messagesDiv.innerHTML += `<div>${message}</div>`;
+        messagesDiv.scrollTop = messagesDiv.scrollHeight;
+    }
+</script>
+</body>
+</html>

--- a/src/main/resources/static/chat-test2.html
+++ b/src/main/resources/static/chat-test2.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>STOMP Chat 테스트 클라이언트</title>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+        }
+
+        input, button {
+            margin: 5px;
+        }
+
+        #messages {
+            margin-top: 20px;
+            border: 1px solid #ccc;
+            padding: 10px;
+            height: 300px;
+            overflow-y: auto;
+            background: #f9f9f9;
+        }
+    </style>
+</head>
+<body>
+<h2>STOMP Chat 테스트 클라이언트</h2>
+
+<label>파티 ID: <input type="number" id="partyId" value="1"/></label><br/>
+<label>사용자 ID: <input type="number" id="userId" value="5"/></label><br/>
+
+<button onclick="enterAndConnect()">입장 + 연결</button>
+<button onclick="disconnect()">연결 해제</button>
+<br/>
+
+<label>메시지: <input type="text" id="messageInput"/></label>
+<button onclick="sendMessage()">보내기</button>
+
+<div id="messages"></div>
+
+<script>
+    const partyId = document.getElementById("partyId").value;
+    userId = parseInt(document.getElementById("userId").value, 10);  // 사용자 ID를 number로 변환
+    memberId = userId;  // memberId는 사용자 ID와 동일하게 설정
+
+    function enterAndConnect() {
+        const partyId = document.getElementById("partyId").value;
+        userId = document.getElementById("userId").value;  // 사용자 ID를 전역 변수에 할당
+        memberId = userId;  // memberId는 사용자 ID와 동일하게 설정
+
+        fetch(`http://localhost:8080/api/chat/enter/${partyId}`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-USER-ID": userId   // 👉 백엔드에서 사용 시 커스텀 헤더로 처리 가능
+            }
+        })
+            .then(res => res.json())
+            .then(data => {
+                log("✅ 입장 성공: " + JSON.stringify(data));
+                connectStomp(partyId);
+            })
+            .catch(err => {
+                log("❌ 입장 실패: " + err);
+            });
+    }
+
+    function connectStomp(partyId) {
+        const socket = new SockJS("http://localhost:8080/ws");  // WebSocket URL
+        stompClient = Stomp.over(socket);
+
+        stompClient.connect({}, function (frame) {
+            log("🟢 STOMP 연결됨");
+
+            // STOMP 구독
+            stompClient.subscribe(`/topic/chat/party/${partyId}`, function (msg) {
+                log("📥 메시지: " + msg.body);
+            });
+
+            stompClient.subscribe(`/topic/chat/party/${partyId}/members`, function (msg) {
+                log("👥 멤버 갱신: " + msg.body);
+            });
+        }, function (error) {
+            log("❌ STOMP 연결 실패: " + error);
+        });
+    }
+
+    function disconnect() {
+        const partyId = document.getElementById("partyId").value;
+
+        // 먼저 퇴장 요청
+        fetch(`http://localhost:8080/api/chat/leave/${partyId}`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-USER-ID": userId
+            }
+        })
+            .then(res => {
+                if (!res.ok) throw new Error("퇴장 실패");
+                log("🚪 퇴장 요청 완료");
+            })
+            .catch(err => {
+                log("❌ 퇴장 요청 실패: " + err);
+            })
+            .finally(() => {
+                // STOMP 연결 해제
+                if (stompClient) {
+                    stompClient.disconnect(() => {
+                        log("🔴 STOMP 연결 해제됨");
+                    });
+                }
+            });
+    }
+
+    function sendMessage() {
+        const partyId = document.getElementById("partyId").value;
+        const message = document.getElementById("messageInput").value;
+
+        if (!stompClient || !stompClient.connected) {
+            log("❌ STOMP 연결이 안 됨! 메시지를 보낼 수 없음.");
+            return;
+        }
+
+        console.log("멤버 ID", memberId)
+        stompClient.send(`/app/chat.send/${partyId}/member/${memberId}`, {}, JSON.stringify(message));
+        log("📤 보낸 메시지: " + JSON.stringify(messagePayload));
+    }
+
+    function log(message) {
+        const messagesDiv = document.getElementById("messages");
+        messagesDiv.innerHTML += `<div>${message}</div>`;
+        messagesDiv.scrollTop = messagesDiv.scrollHeight;
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
# 1. 채팅방 관련 엔티티 및 DTO 생성
- 채팅방 관련 엔티티 및 DTO 생성
- 정책상 우선 메시지 보관은 하지 않으므로, 해당 부분 제외

# 2. 채팅방 생성
- 파티 생성 시 파티의 채팅방 자동 생성

# 3. 채팅방 입장
- 채팅방 입장 기능 구현
- 관련된 인증/인가 진행
- 중복 참여 불가
- 채팅 참여자는 `ChatMember` 엔티티에 등록
- 입장 시 메시지 브로드캐스트

# 4. 채팅방 퇴장
- 채팅방 퇴장 기능 구현
- 퇴장 시 정책에 따라 브로드캐스트 생략하고 채팅방 제거
- 퇴장 시 제거
- 퇴장 시 메시지 브로드캐스트

# 5. 웹소켓 구현 (STOMP)
- `WebSocketConfig` 등록
- `JWT` 를 사용해서 `HandshakeInterceptor` 등록
- 기존 `UserContext` 는 사용 불가능
  - 웹소켓은 `Http` 요청이 아니기 때문에 기존 `@RequestScope` 빈 클래스 사용 불가
  - `WebSocektUserContext` 를 웹소켓 보안 및 멤버 관련 필드 획득용으로 새로 생성

# 6. 채팅
- 채팅 기능 구현
- `@MessageMapping` 이용해 메시지 브로드캐스트
- 현재 테스트 단계에서 인증정보를 사용할 수 없기 때문에, 테스트용 컨트롤러 하나 추가 생성 및 반영
- 채팅 메시지 및 실시간 갱신 채팅 멤버 데이터 브로드캐스트 기능 구현

# 7. 채팅방 삭제 스케쥴링
- 10분마다 채팅방 확인 스케쥴링
- 삭제 대상 채팅방이 존재하면, __이벤트 리스너__를 통해 삭제 진행
- 모든 삭제가 실패하면 `EventListenerExcpeiton` 을 발생시켜, 이벤트 리스너 쪽 문제임을 명시

# 8. 로그백 수정
- 파티 삭제 관련 로그를 따로 보관하기로 결정
- 로그백을 수정하여, 파티 삭제 관련 보관 파일을 분기
- 성공하면 폴더/info, 실패하면 폴더/error에 삭제 및 성공되는 기록들 별도로 저장

# 9. 채팅 테스트 HTML 생성
- 추후 삭제 예정
- `STOMP` 를 사용한 다대다 통신이 잘 이루어지는지 확인
- 추후 `SpringSecurityContext` 정보들을 사용하게 될 때, 잘 작동하는지 __반드시 확인 필요__

# 10. BaseInit 수정
- 파티 쪽 BaseInit 수정
- 기존 Party 가 Save되지 않던 버그 수정
- Service를 따로 사용하지 않고 Party로 생성해서 저장

# 11. TitleEvaluator 수정
- Self-Invocation 문제 해결

# 12. 파티 생성 버그 수정
- `Title` 관련 기능이 들어오고 나서 문제 발생한 부분 수정
- `Dirty-Checking` 미사용으로 변경
  - `PartyRepository` 에 `Party` 명시적으로 저장