### PR TITLE
[REFACTOR] 파티 관련 기능 리팩토링

### DIFF
--- a/src/main/java/com/ll/playon/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/ll/playon/domain/chat/controller/ChatController.java
@@ -27,8 +27,9 @@ public class ChatController {
     public RsData<GetChatRoomResponse> enterPartyRoom(@PathVariable long partyId,
                                                       @RequestHeader("X-USER-ID") long userId) {
         // TODO: 배포 시 주석 해제, @RequestHeader 삭제
-//        Member actor = this.userContext.getActor();
+//        Member actor = this.userContext.getActualActor();
         Member actor = this.userContext.findById(userId);
+        System.out.println("ACTOR 정보 : " + actor.getId());
 
         return RsData.success(HttpStatus.OK, this.chatService.enterPartyRoom(actor, partyId));
     }

--- a/src/main/java/com/ll/playon/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/ll/playon/domain/chat/dto/ChatMessageDto.java
@@ -40,7 +40,7 @@ public record ChatMessageDto(
 //                member.getTitle(),
                 member.getNickname(),
                 member.getProfileImg(),
-                "[" + member.getNickname() + " ]님이 입장하셨습니다.",
+                "[ " + member.getNickname() + " ] 님이 입장하셨습니다.",
                 LocalDateTime.now()
         );
     }

--- a/src/main/java/com/ll/playon/domain/chat/entity/ChatMember.java
+++ b/src/main/java/com/ll/playon/domain/chat/entity/ChatMember.java
@@ -7,7 +7,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +17,12 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@Table(
+        name = "chat_member",
+        indexes = {
+                @Index(name = "idx_chat_member_party_room_id_party_member_id", columnList = "party_room_id, party_member_id")
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/com/ll/playon/domain/chat/entity/PartyRoom.java
+++ b/src/main/java/com/ll/playon/domain/chat/entity/PartyRoom.java
@@ -7,7 +7,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,6 +20,12 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@Table(
+        name = "party_room",
+        indexes = {
+                @Index(name = "idx_party_room_party_id_created_at", columnList = "party_id, created_at")
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/com/ll/playon/domain/chat/event/ChatRoomDetectedAfterGameStartedEvent.java
+++ b/src/main/java/com/ll/playon/domain/chat/event/ChatRoomDetectedAfterGameStartedEvent.java
@@ -3,7 +3,7 @@ package com.ll.playon.domain.chat.event;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
-public record PartyRoomsDeleteEvent(
+public record ChatRoomDetectedAfterGameStartedEvent(
         @NotNull
         List<Long> candidateIds
 ) {

--- a/src/main/java/com/ll/playon/domain/chat/listener/PartyRoomEventListener.java
+++ b/src/main/java/com/ll/playon/domain/chat/listener/PartyRoomEventListener.java
@@ -1,7 +1,7 @@
 package com.ll.playon.domain.chat.listener;
 
 import com.ll.playon.domain.chat.dto.ChatMemberCountDto;
-import com.ll.playon.domain.chat.event.PartyRoomsDeleteEvent;
+import com.ll.playon.domain.chat.event.ChatRoomDetectedAfterGameStartedEvent;
 import com.ll.playon.domain.chat.policy.PartyRoomDeletePolicy;
 import com.ll.playon.domain.chat.repository.ChatMemberRepository;
 import com.ll.playon.domain.chat.repository.PartyRoomRepository;
@@ -24,7 +24,7 @@ public class PartyRoomEventListener {
     private final PartyRoomRepository partyRoomRepository;
 
     @EventListener
-    public void deletePartyRooms(PartyRoomsDeleteEvent event) {
+    public void handle(ChatRoomDetectedAfterGameStartedEvent event) {
         int successCount = 0;
         List<Long> failedIds = new ArrayList<>();
 

--- a/src/main/java/com/ll/playon/domain/chat/repository/ChatMemberRepository.java
+++ b/src/main/java/com/ll/playon/domain/chat/repository/ChatMemberRepository.java
@@ -22,7 +22,7 @@ public interface ChatMemberRepository extends JpaRepository<ChatMember, Long> {
     @Query("""
             SELECT new com.ll.playon.domain.chat.dto.ChatMemberCountDto(cm.partyRoom.id, COUNT(cm))
             FROM ChatMember cm
-            WHERE cm.partyRoom.id IN :partyRoomIds
+            WHERE cm.partyRoom.id IN :candidateIds
             GROUP BY cm.partyRoom.id
             """)
     List<ChatMemberCountDto> countByPartyRoomIds(@Param("candidateIds") List<Long> candidateIds);

--- a/src/main/java/com/ll/playon/domain/chat/scheduled/DeletePartyRoomsScheduler.java
+++ b/src/main/java/com/ll/playon/domain/chat/scheduled/DeletePartyRoomsScheduler.java
@@ -1,11 +1,12 @@
 package com.ll.playon.domain.chat.scheduled;
 
-import com.ll.playon.domain.chat.event.PartyRoomsDeleteEvent;
+import com.ll.playon.domain.chat.event.ChatRoomDetectedAfterGameStartedEvent;
 import com.ll.playon.domain.chat.repository.PartyRoomRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -15,13 +16,13 @@ public class DeletePartyRoomsScheduler {
     private final ApplicationEventPublisher eventPublisher;
 
     // TODO: 배포환경에서 주석 해제
-//    @Scheduled(fixedDelay = 1000 * 60 * 10)
+    @Scheduled(fixedDelay = 1000 * 60 * 10)
     public void deleteUnusedPartyRooms() {
         LocalDateTime deadlineTime = LocalDateTime.now().minusMinutes(5);
         List<Long> candidates = this.partyRoomRepository.findDeletablePartyRooms(deadlineTime);
 
         if (!candidates.isEmpty()) {
-            this.eventPublisher.publishEvent(new PartyRoomsDeleteEvent(candidates));
+            this.eventPublisher.publishEvent(new ChatRoomDetectedAfterGameStartedEvent(candidates));
         }
     }
 }

--- a/src/main/java/com/ll/playon/domain/image/listener/ImageEventListener.java
+++ b/src/main/java/com/ll/playon/domain/image/listener/ImageEventListener.java
@@ -25,7 +25,7 @@ public class ImageEventListener {
             maxAttemptsExpression = "#{3}",
             backoff = @Backoff(delay = 2000)
     )
-    public void handleImageDelete(ImageDeleteEvent event) {
+    public void handle(ImageDeleteEvent event) {
         try {
             this.imageService.deleteImageById(ImageType.LOG, event.id());
         } catch (ServiceException ex) {

--- a/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
+++ b/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
@@ -51,14 +51,11 @@ public class PartyController {
     @PostMapping
     @Operation(summary = "파티 생성")
     public RsData<PostPartyResponse> createParty(@RequestBody @Valid PostPartyRequest postPartyRequest) {
-        // TODO : 추후 롤백
-//        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(5L);
+        Member actor = this.userContext.getActualActor();
 
         return RsData.success(HttpStatus.CREATED, this.partyService.createParty(actor, postPartyRequest));
     }
 
-    // TODO : 게임 쪽 나오면 게임 쪽 추가
     @PostMapping("/list")
     @Operation(summary = "조건 및 태그에 맞는 파티 리스트 조회")
     public RsData<PageDto<GetPartyResponse>> getAllParties(
@@ -72,7 +69,7 @@ public class PartyController {
         // TODO : 추후 롤백
 //        정책 고민 (회원만 조회 가능하게 할 것인지)
 //        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(5L);
+        Member actor = this.userContext.getActualActor();
 
         GlobalValidation.checkPageSize(pageSize);
 
@@ -129,7 +126,7 @@ public class PartyController {
                                                 @RequestBody @Valid PutPartyRequest putPartyRequest) {
         // TODO : 추후 롤백
 //        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(5L);
+        Member actor = this.userContext.getActualActor();
 
         return RsData.success(HttpStatus.OK, this.partyService.updateParty(actor, partyId, putPartyRequest));
     }
@@ -140,7 +137,7 @@ public class PartyController {
     public void deleteParty(@PathVariable long partyId) {
         // TODO : 추후 롤백
 //        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(5L);
+        Member actor = this.userContext.getActualActor();
 
         this.partyService.deleteParty(actor, partyId);
     }
@@ -151,7 +148,7 @@ public class PartyController {
     public void requestParticipation(@PathVariable long partyId) {
         // TODO : 추후 롤백
 //        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(6L);
+        Member actor = this.userContext.getActualActor();
 
         this.partyService.requestParticipation(actor, partyId);
     }
@@ -162,7 +159,7 @@ public class PartyController {
     public void approveParticipation(@PathVariable long partyId, @PathVariable long memberId) {
         // TODO : 추후 롤백
 //        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(5L);
+        Member actor = this.userContext.getActualActor();
 
         this.partyService.approveParticipation(actor, partyId, memberId);
 
@@ -176,7 +173,7 @@ public class PartyController {
     public void rejectParticipation(@PathVariable long partyId, @PathVariable long memberId) {
         // TODO : 추후 롤백
 //        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(5L);
+        Member actor = this.userContext.getActualActor();
 
         this.partyService.rejectParticipation(actor, partyId, memberId);
     }
@@ -186,7 +183,7 @@ public class PartyController {
     public RsData<GetAllPendingMemberResponse> getPartyPendingMembers(@PathVariable long partyId) {
         // TODO : 추후 롤백
 //        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(5L);
+        Member actor = this.userContext.getActualActor();
 
         return RsData.success(HttpStatus.OK, this.partyService.getPartyPendingMembers(actor, partyId));
     }
@@ -197,7 +194,7 @@ public class PartyController {
     public void inviteParty(@PathVariable long partyId, @PathVariable long memberId) {
         // TODO : 추후 롤백
 //        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(5L);
+        Member actor = this.userContext.getActualActor();
 
         this.partyService.inviteParty(actor, partyId, memberId);
     }

--- a/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
@@ -34,7 +34,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(
         name = "party",
         indexes = {
-                @Index(name = "idx_party_status_public_party_at_id", columnList = "partyStatus, is_public, party_at, id"),
+                @Index(name = "idx_party_status_public_party_at_id", columnList = "party_status, is_public, party_at, id"),
+                @Index(name = "idx_party_id_party_at", columnList = "id, party_at")
         }
 )
 @Getter

--- a/src/main/java/com/ll/playon/domain/party/partyLog/controller/PartyLogController.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/controller/PartyLogController.java
@@ -36,8 +36,7 @@ public class PartyLogController {
     public RsData<PartyLogResponse> createPartyLog(@PathVariable long partyId,
                                                    @RequestBody @Valid PostPartyLogRequest request) {
         // TODO : 추후 롤백
-//        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(5L);
+        Member actor = this.userContext.getActualActor();
 
         return RsData.success(HttpStatus.CREATED, this.partyLogService.createPartyLog(actor, partyId, request));
     }
@@ -47,8 +46,7 @@ public class PartyLogController {
     @Operation(summary = "스크린샷 URL 저장")
     public void saveImageUrl(@PathVariable long logId, @PathVariable long partyId, @RequestBody String url) {
         // TODO : 추후 롤백
-//        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(5L);
+        Member actor = this.userContext.getActualActor();
 
         this.partyLogService.saveImageUrl(actor, partyId, logId, url);
     }
@@ -68,8 +66,7 @@ public class PartyLogController {
                                                    @PathVariable long partyId,
                                                    @RequestBody @Valid PutPartyLogRequest request) {
         // TODO : 추후 롤백
-//        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(5L);
+        Member actor = this.userContext.getActualActor();
 
         return RsData.success(HttpStatus.OK, this.partyLogService.updatePartyLog(actor, partyId, logId, request));
     }
@@ -79,8 +76,7 @@ public class PartyLogController {
     @Operation(summary = "파티 로그 삭제")
     public void deletePartyLog(@PathVariable long logId, @PathVariable long partyId) {
         // TODO : 추후 롤백
-//        Member actor = this.userContext.getActor();
-        Member actor = this.userContext.findById(5L);
+        Member actor = this.userContext.getActualActor();
 
         this.partyLogService.deletePartyLog(actor, partyId, logId);
     }

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -43,9 +43,11 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -98,13 +100,16 @@ public class BaseInitData {
 
     @Transactional
     public void makeSampleGames() {
-        if(gameRepository.count() > 0 ) return;
+        if (gameRepository.count() > 0) {
+            return;
+        }
 
         SteamGame game1 = SteamGame.builder()
                 .name("sampleGame1")
                 .appid(1L)
                 .releaseDate(LocalDate.now())
-                .headerImage("https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/87bc28e442a9758e1c6f83bc531cf673a066e472/header_alt_assets_0.jpg?t=1743743917")
+                .headerImage(
+                        "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/87bc28e442a9758e1c6f83bc531cf673a066e472/header_alt_assets_0.jpg?t=1743743917")
                 .requiredAge(0)
                 .developers("sample")
                 .publishers("sample")
@@ -115,7 +120,8 @@ public class BaseInitData {
                 .build();
         SteamImage img1 = SteamImage.builder()
                 .game(game1)
-                .screenshot("https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/ss_31b5597fecf2d9a2904bc9bbf8011aacb18143db.600x338.jpg?t=1743743917")
+                .screenshot(
+                        "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/ss_31b5597fecf2d9a2904bc9bbf8011aacb18143db.600x338.jpg?t=1743743917")
                 .build();
         game1.getScreenshots().add(img1);
         SteamMovie m1 = SteamMovie.builder()
@@ -134,7 +140,8 @@ public class BaseInitData {
                 .name("sampleGame2")
                 .appid(2L)
                 .releaseDate(LocalDate.now())
-                .headerImage("https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/87bc28e442a9758e1c6f83bc531cf673a066e472/header_alt_assets_0.jpg?t=1743743917")
+                .headerImage(
+                        "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/87bc28e442a9758e1c6f83bc531cf673a066e472/header_alt_assets_0.jpg?t=1743743917")
                 .requiredAge(0)
                 .developers("sample")
                 .publishers("sample")
@@ -145,7 +152,8 @@ public class BaseInitData {
                 .build();
         SteamImage img2 = SteamImage.builder()
                 .game(game2)
-                .screenshot("https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/ss_31b5597fecf2d9a2904bc9bbf8011aacb18143db.600x338.jpg?t=1743743917")
+                .screenshot(
+                        "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/ss_31b5597fecf2d9a2904bc9bbf8011aacb18143db.600x338.jpg?t=1743743917")
                 .build();
         game2.getScreenshots().add(img2);
         SteamMovie m2 = SteamMovie.builder()
@@ -161,7 +169,8 @@ public class BaseInitData {
                 .name("sampleGame3")
                 .appid(3L)
                 .releaseDate(LocalDate.now())
-                .headerImage("https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/87bc28e442a9758e1c6f83bc531cf673a066e472/header_alt_assets_0.jpg?t=1743743917")
+                .headerImage(
+                        "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/87bc28e442a9758e1c6f83bc531cf673a066e472/header_alt_assets_0.jpg?t=1743743917")
                 .requiredAge(0)
                 .developers("sample")
                 .publishers("sample")
@@ -172,7 +181,8 @@ public class BaseInitData {
                 .build();
         SteamImage img3 = SteamImage.builder()
                 .game(game3)
-                .screenshot("https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/ss_31b5597fecf2d9a2904bc9bbf8011aacb18143db.600x338.jpg?t=1743743917")
+                .screenshot(
+                        "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/ss_31b5597fecf2d9a2904bc9bbf8011aacb18143db.600x338.jpg?t=1743743917")
                 .build();
         game3.getScreenshots().add(img3);
         SteamMovie m3 = SteamMovie.builder()
@@ -187,7 +197,9 @@ public class BaseInitData {
 
     @Transactional
     public void makeTitles() {
-        if(titleRepository.count() > 0) return;
+        if (titleRepository.count() > 0) {
+            return;
+        }
 
         titleRepository.saveAll(List.of(
                 Title.builder().name("튜토리얼 클리어").description("회원 가입을 완료했다.")
@@ -277,6 +289,7 @@ public class BaseInitData {
                 .username("owner")
                 .nickname("owner")
                 .profileImg("")
+                .password(passwordEncoder.encode("owner"))
                 .lastLoginAt(LocalDateTime.now())
                 .role(Role.USER)
                 .build();
@@ -289,6 +302,7 @@ public class BaseInitData {
                 .username("partyOwner")
                 .nickname("partyOwner")
                 .profileImg("")
+                .password(passwordEncoder.encode("partyOwner"))
                 .lastLoginAt(LocalDateTime.now())
                 .role(Role.USER)
                 .build();
@@ -301,6 +315,7 @@ public class BaseInitData {
                 .username("partyOwner2")
                 .nickname("partyOwner2")
                 .profileImg("")
+                .password(passwordEncoder.encode("partyOwner2"))
                 .lastLoginAt(LocalDateTime.now())
                 .role(Role.USER)
                 .build();
@@ -313,6 +328,7 @@ public class BaseInitData {
                 .username("partyMember")
                 .nickname("partyMember")
                 .profileImg("")
+                .password(passwordEncoder.encode("partyMember"))
                 .lastLoginAt(LocalDateTime.now())
                 .role(Role.USER)
                 .build();
@@ -323,7 +339,9 @@ public class BaseInitData {
 
     @Transactional
     public void makeSampleGuilds() {
-        if (guildRepository.count() != 0) return;
+        if (guildRepository.count() != 0) {
+            return;
+        }
 
         List<Member> members = memberRepository.findAll().stream()
                 .limit(3)
@@ -475,18 +493,20 @@ public class BaseInitData {
     }
 
     // 특정 TagValue가 TagType에 맞는 값인지 확인하는 메서드
+    private static final Map<TagType, Set<TagValue>> VALID_TAG_VALUE_MAP = Map.of(
+            TagType.PARTY_STYLE, EnumSet.of(
+                    TagValue.BEGINNER, TagValue.CASUAL, TagValue.NORMAL,
+                    TagValue.HARDCORE, TagValue.EXTREME, TagValue.COMPLETIONIST, TagValue.SPEEDRUN),
+            TagType.GAME_SKILL, EnumSet.of(
+                    TagValue.MASTER, TagValue.HACKER, TagValue.PRO, TagValue.NEWBIE),
+            TagType.GENDER, EnumSet.of(
+                    TagValue.MALE, TagValue.FEMALE),
+            TagType.SOCIALIZING, EnumSet.of(
+                    TagValue.SOCIAL_FRIENDLY, TagValue.GAME_ONLY, TagValue.NO_CHAT)
+    );
+
     private boolean isValidTagValueForType(TagValue tagValue, TagType tagType) {
-        return switch (tagType) {
-            case PARTY_STYLE ->
-                    tagValue == TagValue.BEGINNER || tagValue == TagValue.CASUAL || tagValue == TagValue.NORMAL
-                    || tagValue == TagValue.HARDCORE || tagValue == TagValue.EXTREME || tagValue == TagValue.COMPLETIONIST
-                    || tagValue == TagValue.SPEEDRUN;
-            case GAME_SKILL -> tagValue == TagValue.MASTER || tagValue == TagValue.HACKER
-                    || tagValue == TagValue.PRO || tagValue == TagValue.NEWBIE;
-            case GENDER -> tagValue == TagValue.MALE || tagValue == TagValue.FEMALE;
-            case SOCIALIZING -> tagValue == TagValue.SOCIAL_FRIENDLY || tagValue == TagValue.GAME_ONLY
-                                || tagValue == TagValue.NO_CHAT;
-        };
+        return VALID_TAG_VALUE_MAP.getOrDefault(tagType, Collections.emptySet()).contains(tagValue);
     }
 
     private List<GuildTag> createSampleGuildTags(Guild guild) {
@@ -531,7 +551,7 @@ public class BaseInitData {
             return;
         }
 
-        if(weeklyGameRepository.count() > 0) {
+        if (weeklyGameRepository.count() > 0) {
             return;
         }
 
@@ -559,7 +579,9 @@ public class BaseInitData {
 
     @Transactional
     public void makeSampleGuildJoinRequests() {
-        if (guildJoinRequestRepository.count() > 0) return;
+        if (guildJoinRequestRepository.count() > 0) {
+            return;
+        }
 
         List<Guild> guilds = guildRepository.findAll();
         List<Member> members = memberRepository.findAll();
@@ -587,7 +609,9 @@ public class BaseInitData {
 
     @Transactional
     public void makeSampleGuildBoards() {
-        if (guildBoardRepository.count() > 0) return;
+        if (guildBoardRepository.count() > 0) {
+            return;
+        }
 
         List<Guild> guilds = guildRepository.findAll();
         Random random = new Random();
@@ -595,7 +619,9 @@ public class BaseInitData {
         for (Guild guild : guilds) {
             List<GuildMember> guildMembers = guildMemberRepository.findAllByGuild(guild);
 
-            if (guildMembers.isEmpty()) continue;
+            if (guildMembers.isEmpty()) {
+                continue;
+            }
 
             int boardCount = 2 + random.nextInt(2); // 2~3개 생성
 
@@ -604,9 +630,11 @@ public class BaseInitData {
 
                 // 태그를 NOTICE로 줄 확률 (30%), 리더/매니저가 아닌 경우 강제로 FREE
                 boolean isNotice = random.nextInt(100) < 30;
-                BoardTag tag = (isNotice && author.getGuildRole().isManagerOrLeader()) ? BoardTag.NOTICE : BoardTag.FREE;
+                BoardTag tag =
+                        (isNotice && author.getGuildRole().isManagerOrLeader()) ? BoardTag.NOTICE : BoardTag.FREE;
 
-                String title = (tag == BoardTag.NOTICE ? "[공지] " : "") + "샘플 게시글 " + UUID.randomUUID().toString().substring(0, 5);
+                String title = (tag == BoardTag.NOTICE ? "[공지] " : "") + "샘플 게시글 " + UUID.randomUUID().toString()
+                        .substring(0, 5);
                 String content = "샘플 내용입니다.\n테스트용입니다.";
 
                 GuildBoard board = GuildBoard.builder()
@@ -647,7 +675,7 @@ public class BaseInitData {
                 }
             }
         }
-}
+    }
 
 
 }

--- a/src/main/java/com/ll/playon/global/security/SecurityConfig.java
+++ b/src/main/java/com/ll/playon/global/security/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain baseSecurityFilterChain(HttpSecurity http) throws Exception {
         http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))  //TODO: 제거
                 .authorizeHttpRequests(authorizeRequests ->
                         authorizeRequests
                                 .anyRequest()
@@ -75,6 +76,7 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         // 허용할 오리진 설정
         configuration.setAllowedOriginPatterns(Arrays.asList(AppConfig.getSiteFrontUrl()));
+        configuration.setAllowedOriginPatterns(Arrays.asList("https://websocketking.com/"));    // TODO: 제거
         // 허용할 HTTP 메서드 설정
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH"));
         // 자격 증명 허용 설정

--- a/src/main/java/com/ll/playon/global/webSocket/config/WebSocketConfig.java
+++ b/src/main/java/com/ll/playon/global/webSocket/config/WebSocketConfig.java
@@ -21,7 +21,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 //                .setAllowedOrigins("*")
                 .setAllowedOriginPatterns("*")
 //                .addInterceptors(jwtHandshakeInterceptor)
-                .withSockJS();  // SockJs Fallback
+                .withSockJS()   // SockJs Fallback
+        ;
     }
 
     @Override

--- a/src/main/java/com/ll/playon/global/webSocket/security/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/ll/playon/global/webSocket/security/JwtHandshakeInterceptor.java
@@ -26,6 +26,10 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 //    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler,
 //                                   Map<String, Object> attributes) throws Exception {
 //        String token = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+////        String token = null;    // TODO: 이 if절 끝까지 삭제
+////        if (request instanceof ServletServerHttpRequest servletRequest) {
+////            token = servletRequest.getServletRequest().getHeader("Authorization");
+////        }
 //
 //        if (token.startsWith("Bearer ")) {
 //            token = token.substring("Bearer ".length());
@@ -33,7 +37,7 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 //            Map<String, Object> payload = this.authTokenService.payload(token);
 //
 //            if (payload != null) {
-//                Long userId = (Long) payload.get("id");
+//                Long userId = ((Number) payload.get("id")).longValue();
 //                attributes.put("userId", userId);
 //                return true;
 //            }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -100,7 +100,7 @@
     </logger>
 
     <!-- 파티 삭제 이벤트 관련 로거 -->
-    <logger name="com.ll.playon.domain.chat.listener.PartyRoomsDeleteEventListener" level="INFO" additivity="false">
+    <logger name="com.ll.playon.domain.chat.listener.PartyRoomEventListener" level="INFO" additivity="false">
         <appender-ref ref="PARTY_DELETE_INFO_FILE"/>
         <appender-ref ref="PARTY_DELETE_ERROR_FILE"/>
         <appender-ref ref="CONSOLE"/>


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?
  - `Postman` 을 통한 `API` 호출 테스트 진행

  <br/>

## 🔎 작업 내용

### 1. 컨트롤러 사용자 정보 획득 방식 변경
- `Party` , `PartyRoom` , `PartyLog` 컨트롤러 사용자 인증 방식 변경
- `JWT` 및 쿠키를 활용하여 유저 정보를 가져오도록 변경

### 2. 인증된 유저 정보 획득
- UserContext에서 멤버 조회를 한 번에 가져오는 `getActualActor` 메서드 추가
- 위의 컨트롤러에서 해당 방식으로 유저 정보 획득

### 3. 인덱스 변경
- 인덱스 추가 및 변경이 필요한 엔티티 변경

### 4. 이벤트명 리팩토링
- 이벤트 이름은 이름으로 어떤 이벤트를 진행할 지 유추할 수 없도록 하라는 강사님의 피드백
- 기존에는 `PartyRoomsDeleteEvent` 이름으로 이벤트를 등록
- 사실만 나타내고 리스너에서 처리하도록 `ChatRoomDetectedAfterGameStartedEvent` 로 클래스명 변경

### 5. 잘못된 바인딩 해결
- `countByPartyRoomIds` 쿼리에서 바인딩 문제 발견
- 파라미터명에 맞추어서 해당 부분 수정

### 6. 파티 조회 정책 변경
- 기존에는 파티 리스트 조회 시 검색 조건과 상관없이 내 파티를 페이지 최상단에 노출
- 정책 재확인, 정책에 따라 코드 변경
- 파티 리스트 조회 시 검색 조건에 맞는 파티 리스트들을 출력하며, 내 파티는 아예 제외

### 7. 채팅방 테스트
- `JWT` 를 이용해서 채팅방에 입장이 가능한지 테스트
- 입장까지는 테스트 완료
- 아직 프론트와 제대로 연동되지 않았기 때문에, 추후 테스트 반드시 필요
- `JwtHandshakeInterceptor` 에서 `Jwt` 를 기반으로 유저 정보를 가져올 때, `userId` 를 제대로 가져오지 못함
  - 타입 변환 오류 발생
  - 기존 타입을 `Long` 타입으로 변환할 수 없는 문제
  - `Number` 로 먼저 감싸고, `longValue()` 메서드를 이용해 `LongType` 으로 변경

### 8. `BaseInit` 변경
- 프론트 형식에 맞춰서 `PartyTag` 가 변경됨
- 이에 따라 `BaseInit` 의 파티 태그 생성 조건도 변경
