### PR TITLE
[FEAT] 스팀 API 장애 대응

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.webjars:sockjs-client:1.5.1'
     implementation 'org.webjars:stomp-websocket:2.3.4'
+    // Resilience4j
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.3.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ll/playon/PlayOnApplication.java
+++ b/src/main/java/com/ll/playon/PlayOnApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
@@ -12,6 +13,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableBatchProcessing
 @EnableFeignClients
 @EnableScheduling
+@EnableAsync
 public class PlayOnApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/ll/playon/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/ll/playon/domain/chat/controller/ChatController.java
@@ -30,7 +30,6 @@ public class ChatController {
         // TODO: 배포 시 주석 해제, @RequestHeader 삭제
 //        Member actor = this.userContext.getActualActor();
         Member actor = this.userContext.findById(userId);
-        System.out.println("ACTOR 정보 : " + actor.getId());
 
         return RsData.success(HttpStatus.OK, this.chatService.enterPartyRoom(actor, partyId));
     }

--- a/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.ll.playon.domain.game.game.dto.GameListResponse;
 import com.ll.playon.domain.member.dto.*;
 import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.member.service.MemberService;
+import com.ll.playon.domain.member.service.SteamAsyncService;
 import com.ll.playon.global.exceptions.ErrorCode;
 import com.ll.playon.global.response.RsData;
 import com.ll.playon.global.security.UserContext;
@@ -25,6 +26,7 @@ import java.util.List;
 public class MemberController {
 
     private final MemberService memberService;
+    private final SteamAsyncService steamAsyncService;
     private final UserContext userContext;
 
     @PostMapping("/login")
@@ -88,7 +90,7 @@ public class MemberController {
     public RsData<String> linkSteamGames() {
         Member actor = userContext.getActor();
         if(ObjectUtils.isEmpty(actor)) throw ErrorCode.UNAUTHORIZED.throwServiceException();
-        memberService.getUserGamesAndCheckGenres(actor);
+        steamAsyncService.getUserGamesAndCheckGenres(actor);
         return RsData.success(HttpStatus.OK, "성공");
     }
 

--- a/src/main/java/com/ll/playon/domain/member/service/SignupEvent.java
+++ b/src/main/java/com/ll/playon/domain/member/service/SignupEvent.java
@@ -1,0 +1,7 @@
+package com.ll.playon.domain.member.service;
+
+import com.ll.playon.domain.member.entity.Member;
+
+public record SignupEvent(
+        Member member
+) {}

--- a/src/main/java/com/ll/playon/domain/member/service/SignupEventListener.java
+++ b/src/main/java/com/ll/playon/domain/member/service/SignupEventListener.java
@@ -1,0 +1,17 @@
+package com.ll.playon.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class SignupEventListener {
+    private final SteamAsyncService steamAsyncService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(SignupEvent event) {
+        steamAsyncService.getUserGamesAndCheckGenres(event.member());
+    }
+}

--- a/src/main/java/com/ll/playon/domain/member/service/SteamAsyncService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/SteamAsyncService.java
@@ -1,0 +1,63 @@
+package com.ll.playon.domain.member.service;
+
+import com.ll.playon.domain.game.game.entity.SteamGenre;
+import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.member.entity.MemberSteamData;
+import com.ll.playon.domain.member.repository.MemberRepository;
+import com.ll.playon.domain.member.repository.MemberSteamDataRepository;
+import com.ll.playon.domain.title.entity.enums.ConditionType;
+import com.ll.playon.domain.title.service.TitleEvaluator;
+import com.ll.playon.global.steamAPI.SteamAPI;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SteamAsyncService {
+
+    private final SteamAPI steamAPI;
+    private final MemberRepository memberRepository;
+    private final TitleEvaluator titleEvaluator;
+    private final MemberSteamDataRepository memberSteamDataRepository;
+
+    @Async
+    @Transactional
+    public void getUserGamesAndCheckGenres(Member member) {
+        int before = member.getGames().size();
+
+        List<Long> userGames = steamAPI.getUserGames(member.getSteamId());
+        if(!userGames.isEmpty()) {
+            SteamGenre preferredGenre = steamAPI.getPreferredGenre(userGames);
+            memberRepository.save(member.toBuilder().preferredGenre(preferredGenre.getName()).build());
+            saveUserGameList(userGames, member);
+        }
+
+        int after = userGames.size();
+
+        // 스팀 게임 소유 칭호
+        titleEvaluator.gameCountCheck(ConditionType.STEAM_GAME_COUNT, member, after - before);
+    }
+
+    public void saveUserGameList(List<Long> gameList, Member member) {
+        Set<Long> existingGames = member.getGames().stream()
+                .map(MemberSteamData::getAppId)
+                .collect(Collectors.toSet());
+
+        List<MemberSteamData> games = gameList.stream()
+                .filter(appid -> !existingGames.contains(appid))
+                .map(appId -> MemberSteamData.builder()
+                        .appId(appId)
+                        .member(member)
+                        .build())
+                .toList();
+
+        member.getGames().addAll(games);
+        memberSteamDataRepository.saveAll(games);
+    }
+}

--- a/src/main/java/com/ll/playon/domain/member/service/SteamAsyncService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/SteamAsyncService.java
@@ -7,6 +7,7 @@ import com.ll.playon.domain.member.repository.MemberRepository;
 import com.ll.playon.domain.member.repository.MemberSteamDataRepository;
 import com.ll.playon.domain.title.entity.enums.ConditionType;
 import com.ll.playon.domain.title.service.TitleEvaluator;
+import com.ll.playon.global.exceptions.ErrorCode;
 import com.ll.playon.global.steamAPI.SteamAPI;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +29,10 @@ public class SteamAsyncService {
 
     @Async
     @Transactional
-    public void getUserGamesAndCheckGenres(Member member) {
+    public void getUserGamesAndCheckGenres(Member actor) {
+        Member member = memberRepository.findById(actor.getId())
+                .orElseThrow(ErrorCode.MEMBER_NOT_FOUND::throwServiceException);
+
         int before = member.getGames().size();
 
         List<Long> userGames = steamAPI.getUserGames(member.getSteamId());

--- a/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
@@ -20,6 +20,9 @@ public enum ErrorCode {
     EXTERNAL_API_UNEXPECTED_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "API 응답이 올바르지 않습니다"),
     EXTERNAL_API_UNEXPECTED_REQUEST(HttpStatus.BAD_REQUEST, "API 요청이 올바르지 않습니다"),
     EXTERNAL_API_COMMUNICATION_ERROR(HttpStatus.BAD_GATEWAY, "API 요청 중 오류가 발생했습니다."),
+    STEAM_TOO_MANY_REQUEST(HttpStatus.TOO_MANY_REQUESTS, "현재 요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
+    STEAM_NOT_RESPONDED(HttpStatus.SERVICE_UNAVAILABLE, "스팀 서버가 일시적으로 응답하지 않습니다. 잠시 후 다시 시도해주세요."),
+    STEAM_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "현재 스팀 서버가 불안정하여 요청이 차단되었습니다. 잠시 후 다시 시도해주세요."),
 
     // S3
     S3_PRESIGNED_URL_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PresignedURL 생성에 실패하였습니다."),

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -34,6 +34,9 @@ import com.ll.playon.domain.member.service.MemberService;
 import com.ll.playon.domain.party.party.entity.Party;
 import com.ll.playon.domain.party.party.entity.PartyMember;
 import com.ll.playon.domain.party.party.entity.PartyTag;
+import com.ll.playon.domain.member.service.SteamAsyncService;
+import com.ll.playon.domain.party.party.dto.request.PartyTagRequest;
+import com.ll.playon.domain.party.party.dto.request.PostPartyRequest;
 import com.ll.playon.domain.party.party.repository.PartyRepository;
 import com.ll.playon.domain.party.party.type.PartyRole;
 import com.ll.playon.domain.title.entity.Title;
@@ -83,6 +86,7 @@ public class BaseInitData {
     private final TitleRepository titleRepository;
     private final GameRepository gameRepository;
     private final PartyRoomRepository partyRoomRepository;
+    private final SteamAsyncService steamAsyncService;
 
     @Autowired
     @Lazy
@@ -275,18 +279,18 @@ public class BaseInitData {
                 .role(Role.USER).build();
         memberRepository.save(sampleMember1);
         List<Long> gameAppIds = Arrays.asList(1L, 2L, 3L);
-        memberService.saveUserGameList(gameAppIds, sampleMember1);
+        steamAsyncService.saveUserGameList(gameAppIds, sampleMember1);
 
         Member sampleMember2 = Member.builder()
                 .steamId(456L).username("sampleUser2").lastLoginAt(LocalDateTime.now()).role(Role.USER).build();
         memberRepository.save(sampleMember2);
-        memberService.saveUserGameList(gameAppIds, sampleMember2);
+        steamAsyncService.saveUserGameList(gameAppIds, sampleMember2);
 
         Member sampleMember3 = Member.builder()
                 .steamId(789L).username("sampleUser3").lastLoginAt(LocalDateTime.now()).role(Role.USER).build();
         memberRepository.save(sampleMember3);
 
-        memberService.saveUserGameList(gameAppIds, sampleMember3);
+        steamAsyncService.saveUserGameList(gameAppIds, sampleMember3);
 
         Member noSteamMember = Member.builder()
                 .username("noSteamMember").nickname("noSteamUser").password(passwordEncoder.encode("noSteam123"))
@@ -305,7 +309,7 @@ public class BaseInitData {
                 .build();
         memberRepository.save(owner);
 
-        memberService.saveUserGameList(gameAppIds, owner);
+        steamAsyncService.saveUserGameList(gameAppIds, owner);
 
         Member partyOwner = Member.builder()
                 .steamId(555L)
@@ -318,7 +322,7 @@ public class BaseInitData {
                 .build();
         memberRepository.save(partyOwner);
 
-        memberService.saveUserGameList(gameAppIds, partyOwner);
+        steamAsyncService.saveUserGameList(gameAppIds, partyOwner);
 
         Member partyOwner2 = Member.builder()
                 .steamId(556L)
@@ -331,7 +335,7 @@ public class BaseInitData {
                 .build();
         memberRepository.save(partyOwner2);
 
-        memberService.saveUserGameList(gameAppIds, partyOwner2);
+        steamAsyncService.saveUserGameList(gameAppIds, partyOwner2);
 
         Member partyMember = Member.builder()
                 .steamId(2252L)
@@ -344,7 +348,7 @@ public class BaseInitData {
                 .build();
         memberRepository.save(partyMember);
 
-        memberService.saveUserGameList(gameAppIds, partyMember);
+        steamAsyncService.saveUserGameList(gameAppIds, partyMember);
     }
 
     @Transactional

--- a/src/main/java/com/ll/playon/global/openFeign/SteamApiClient.java
+++ b/src/main/java/com/ll/playon/global/openFeign/SteamApiClient.java
@@ -2,6 +2,11 @@ package com.ll.playon.global.openFeign;
 
 import com.ll.playon.global.openFeign.dto.ownedGames.SteamGameResponse;
 import com.ll.playon.global.openFeign.dto.playerSummaries.SteamResponse;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import io.github.resilience4j.retry.annotation.Retry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -10,17 +15,34 @@ import org.springframework.web.bind.annotation.RequestParam;
 @FeignClient(name = "steamApiClient", url = "https://api.steampowered.com")
 public interface SteamApiClient {
 
+    Logger log = LoggerFactory.getLogger(SteamApiClient.class);
+
     // GET 요청을 해당 엔드포인트로 보냄
     @GetMapping("/ISteamUser/GetPlayerSummaries/v2/")
+    @Retry(name = "steamApiRetry")
+    @RateLimiter(name = "steamApiRateLimiter")
+    @CircuitBreaker(name = "steamApiCircuitBreaker", fallbackMethod = "fallbackPlayerSummary")
     SteamResponse getPlayerSummaries(
-            // API 키와 steamId 를 쿼리 파라미터로 전달
             @RequestParam("key") String apiKey,
             @RequestParam("steamids") String steamIds
     );
 
     @GetMapping("IPlayerService/GetOwnedGames/v1/")
+    @Retry(name = "steamApiRetry")
+    @RateLimiter(name = "steamApiRateLimiter")
+    @CircuitBreaker(name = "steamApiCircuitBreaker", fallbackMethod = "fallbackOwnedGames")
     SteamGameResponse getPlayerOwnedGames(
             @RequestParam("key") String apiKey,
             @RequestParam("steamid") String steamId
     );
+
+    default SteamGameResponse fallbackOwnedGames(String apiKey, String steamId, Throwable t) {
+        log.warn("GetOwnedGames fallback: {}", t.getMessage());
+        return new SteamGameResponse();
+    }
+
+    default SteamResponse fallbackPlayerSummary(String apiKey, String steamIds, Throwable t) {
+        log.warn("GetPlayerSummaries fallback: {}", t.getMessage());
+        return new SteamResponse();
+    }
 }

--- a/src/main/java/com/ll/playon/global/security/UserContext.java
+++ b/src/main/java/com/ll/playon/global/security/UserContext.java
@@ -92,7 +92,6 @@ public class UserContext {
     // JWT 생성하고 쿠키 생성
     public String makeAuthCookies(Member user) {
         String accessToken = memberService.genAccessToken(user);
-        System.out.println(accessToken);// TODO: 삭제
 
         setCookie("apiKey", user.getApiKey());
         setCookie("accessToken", accessToken);

--- a/src/main/java/com/ll/playon/global/steamAPI/SteamAPI.java
+++ b/src/main/java/com/ll/playon/global/steamAPI/SteamAPI.java
@@ -38,8 +38,6 @@ public class SteamAPI {
 
     private static final int MAX_GAMES_TO_ANALYZE = 30;
 
-    // TODO : 스팀 API 장애 대응
-
     @Value("${custom.steam.apikey}")
     private String apikey;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,20 +60,20 @@ resilience4j:
     instances:
       steamApiRetry:
         max-attempts: 3
-        wait-duration: 1s
+        wait-duration: 2s
 
   ratelimiter:
     instances:
       steamApiRateLimiter:
-        limit-for-period: 20
-        limit-refresh-period: 30s
-        timeout-duration: 1000ms
+        limit-for-period: 38
+        limit-refresh-period: 60s
+        timeout-duration: 2000ms
 
   circuitbreaker:
     instances:
       steamApiCircuitBreaker:
         register-health-indicator: true
-        failure-rate-threshold: 50
-        sliding-window-size: 10
-        minimum-number-of-calls: 5
-        wait-duration-in-open-state: 30s
+        failure-rate-threshold: 30
+        sliding-window-size: 20
+        minimum-number-of-calls: 10
+        wait-duration-in-open-state: 60s

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,3 +54,26 @@ custom:
     secretKey: ON_SECRET
   accessToken:
     expirationSeconds: "#{60 * 20}"
+
+resilience4j:
+  retry:
+    instances:
+      steamApiRetry:
+        max-attempts: 3
+        wait-duration: 1s
+
+  ratelimiter:
+    instances:
+      steamApiRateLimiter:
+        limit-for-period: 20
+        limit-refresh-period: 30s
+        timeout-duration: 1000ms
+
+  circuitbreaker:
+    instances:
+      steamApiCircuitBreaker:
+        register-health-indicator: true
+        failure-rate-threshold: 50
+        sliding-window-size: 10
+        minimum-number-of-calls: 5
+        wait-duration-in-open-state: 30s

--- a/src/test/java/com/ll/playon/domain/member/controller/SteamAuthAsyncTest.java
+++ b/src/test/java/com/ll/playon/domain/member/controller/SteamAuthAsyncTest.java
@@ -1,0 +1,170 @@
+package com.ll.playon.domain.member.controller;
+
+import com.ll.playon.domain.member.TestMemberHelper;
+import com.ll.playon.domain.member.repository.MemberSteamDataRepository;
+import com.ll.playon.global.openFeign.SteamApiClient;
+import com.ll.playon.global.openFeign.SteamOpenIdClient;
+import com.ll.playon.global.openFeign.SteamStoreClient;
+import com.ll.playon.global.openFeign.dto.ownedGames.Game;
+import com.ll.playon.global.openFeign.dto.ownedGames.GameResponse;
+import com.ll.playon.global.openFeign.dto.ownedGames.SteamGameResponse;
+import com.ll.playon.global.openFeign.dto.playerSummaries.Player;
+import com.ll.playon.global.openFeign.dto.playerSummaries.PlayerResponse;
+import com.ll.playon.global.openFeign.dto.playerSummaries.SteamResponse;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.util.LinkedMultiValueMap;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+public class SteamAuthAsyncTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private TestMemberHelper testMemberHelper;
+
+    @Autowired
+    private MemberSteamDataRepository memberSteamDataRepository;
+
+    @MockitoBean
+    private SteamOpenIdClient mockSteamOpenIdClient;
+
+    @MockitoBean
+    private SteamApiClient mockSteamApiClient;
+
+    @MockitoBean
+    private SteamStoreClient mockSteamStoreClient;
+
+    @Value("${custom.steam.apikey}")
+    private String apikey;
+
+    private void setFakeLoginResponse() {
+        Mockito.when(mockSteamOpenIdClient.validateSteamId(any()))
+                .thenReturn("is_valid:true");
+    }
+
+    private void setFakeProfileResponse() {
+        SteamResponse fakeSteamResponse = new SteamResponse();
+        PlayerResponse playerResponse = new PlayerResponse();
+        Player player = new Player();
+
+        player.setNickname("everydayplayday");
+        player.setAvatar("https://avatars.steamstatic.com/66acac8c7e55dd6a4c70dc5eb1d783c015a1d284_medium.jpg");
+
+        playerResponse.setPlayers(List.of(player));
+        fakeSteamResponse.setResponse(playerResponse);
+
+        Mockito.when(mockSteamApiClient.getPlayerSummaries(eq(apikey), any()))
+                .thenReturn(fakeSteamResponse);
+    }
+
+    private void setFakeGamesResponse() {
+        SteamGameResponse fakeSteamGameResponse = new SteamGameResponse();
+        GameResponse gameResponse = new GameResponse();
+        Game game1 = new Game();
+        Game game2 = new Game();
+        Game game3 = new Game();
+
+        game1.setAppId("2246340");
+        game1.setPlaytime(111);
+        game2.setAppId("2680010");
+        game2.setPlaytime(222);
+        game3.setAppId("2456740");
+        game3.setPlaytime(333);
+
+        gameResponse.setGames(List.of(game1, game2, game3));
+        fakeSteamGameResponse.setResponse(gameResponse);
+
+        Mockito.when(mockSteamApiClient.getPlayerOwnedGames(eq(apikey), any()))
+                .thenReturn(fakeSteamGameResponse);
+    }
+
+    @Test
+    @DisplayName("스팀 회원가입 성공 테스트, 스팀 id 123456, 새로운 사용자")
+    void signupNewUser() throws Exception {
+        setFakeLoginResponse();
+        setFakeProfileResponse();
+        setFakeGamesResponse();
+
+        ResultActions resultActions = mvc.perform(
+                get("/api/auth/steam/callback/signup")
+                        .params(new LinkedMultiValueMap<>(Collections.singletonMap("openid.mode", List.of("id_res"))))
+                        .params(new LinkedMultiValueMap<>(Collections.singletonMap("openid.claimed_id", List.of("https://steamcommunity.com/openid/id/123456"))))
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+        );
+
+        Thread.sleep(1000);
+
+        resultActions.andExpect(status().isOk())
+                .andExpect(
+                result -> {
+                    Cookie accessTokenCookie = result.getResponse().getCookie("accessToken");
+                    assertThat(accessTokenCookie).isNotNull();
+                    assertThat(accessTokenCookie.getValue()).isNotBlank();
+                    assertThat(accessTokenCookie.getPath()).isEqualTo("/");
+                    assertThat(accessTokenCookie.isHttpOnly()).isTrue();
+
+                    Cookie apiKeyCookie = result.getResponse().getCookie("apiKey");
+                    assertThat(apiKeyCookie).isNotNull();
+                    assertThat(apiKeyCookie.getValue()).isNotBlank();
+                    assertThat(apiKeyCookie.getPath()).isEqualTo("/");
+                    assertThat(apiKeyCookie.isHttpOnly()).isTrue();
+                }
+        );
+
+        Mockito.verify(mockSteamOpenIdClient).validateSteamId(any());
+        Mockito.verify(mockSteamApiClient).getPlayerOwnedGames(eq(apikey), any());
+        Mockito.verify(mockSteamApiClient).getPlayerSummaries(eq(apikey), any());
+    }
+
+    @Test
+    @DisplayName("스팀 계정 연동 성공 테스트, noSteamMember")
+    void linkNoSteamMember() throws Exception {
+        long initCount = memberSteamDataRepository.count();
+        setFakeLoginResponse();
+        setFakeGamesResponse();
+
+        MockHttpServletRequestBuilder request = get("/api/auth/steam/callback/link")
+                        .params(new LinkedMultiValueMap<>(Collections.singletonMap("openid.mode", List.of("id_res"))))
+                        .params(new LinkedMultiValueMap<>(Collections.singletonMap("openid.claimed_id", List.of("https://steamcommunity.com/openid/id/12345"))))
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        ResultActions resultActions = testMemberHelper.requestWithUserAuth("noSteamMember", request);
+
+        Thread.sleep(1000);
+
+        resultActions.andExpect(status().isOk());
+        Mockito.verify(mockSteamOpenIdClient).validateSteamId(any());
+        Mockito.verify(mockSteamApiClient).getPlayerOwnedGames(eq(apikey), any());
+
+        // count 가 3 증가했는지 검증
+        long finalCount = memberSteamDataRepository.count();
+        assertEquals(initCount + 3, finalCount);
+    }
+}
+

--- a/src/test/java/com/ll/playon/domain/member/controller/SteamAuthTest.java
+++ b/src/test/java/com/ll/playon/domain/member/controller/SteamAuthTest.java
@@ -5,13 +5,8 @@ import com.ll.playon.domain.member.repository.MemberSteamDataRepository;
 import com.ll.playon.global.openFeign.SteamApiClient;
 import com.ll.playon.global.openFeign.SteamOpenIdClient;
 import com.ll.playon.global.openFeign.SteamStoreClient;
-import com.ll.playon.global.openFeign.dto.ownedGames.Game;
-import com.ll.playon.global.openFeign.dto.ownedGames.GameResponse;
-import com.ll.playon.global.openFeign.dto.ownedGames.SteamGameResponse;
-import com.ll.playon.global.openFeign.dto.playerSummaries.Player;
-import com.ll.playon.global.openFeign.dto.playerSummaries.PlayerResponse;
-import com.ll.playon.global.openFeign.dto.playerSummaries.SteamResponse;
 import jakarta.servlet.http.Cookie;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -24,16 +19,13 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 
 import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -65,44 +57,8 @@ public class SteamAuthTest {
     private String apikey;
 
     private void setFakeLoginResponse() {
-        Mockito.when(mockSteamOpenIdClient.validateSteamId(Mockito.any()))
+        Mockito.when(mockSteamOpenIdClient.validateSteamId(any()))
                 .thenReturn("is_valid:true");
-    }
-
-    private void setFakeProfileResponse() {
-        SteamResponse fakeSteamResponse = new SteamResponse();
-        PlayerResponse playerResponse = new PlayerResponse();
-        Player player = new Player();
-
-        player.setNickname("everydayplayday");
-        player.setAvatar("https://avatars.steamstatic.com/66acac8c7e55dd6a4c70dc5eb1d783c015a1d284_medium.jpg");
-
-        playerResponse.setPlayers(List.of(player));
-        fakeSteamResponse.setResponse(playerResponse);
-
-        Mockito.when(mockSteamApiClient.getPlayerSummaries(eq(apikey),Mockito.any()))
-                .thenReturn(fakeSteamResponse);
-    }
-
-    private void setFakeGamesResponse() {
-        SteamGameResponse fakeSteamGameResponse = new SteamGameResponse();
-        GameResponse gameResponse = new GameResponse();
-        Game game1 = new Game();
-        Game game2 = new Game();
-        Game game3 = new Game();
-
-        game1.setAppId("2246340");
-        game1.setPlaytime(111);
-        game2.setAppId("2680010");
-        game2.setPlaytime(222);
-        game3.setAppId("2456740");
-        game3.setPlaytime(333);
-
-        gameResponse.setGames(List.of(game1, game2, game3));
-        fakeSteamGameResponse.setResponse(gameResponse);
-
-        Mockito.when(mockSteamApiClient.getPlayerOwnedGames(eq(apikey),Mockito.any()))
-                .thenReturn(fakeSteamGameResponse);
     }
 
     @Test
@@ -134,43 +90,7 @@ public class SteamAuthTest {
                 }
         );
 
-        Mockito.verify(mockSteamOpenIdClient).validateSteamId(Mockito.any());
-    }
-
-    @Test
-    @DisplayName("스팀 회원가입 성공 테스트, 스팀 id 1234, 새로운 사용자")
-    void signupNewUser() throws Exception {
-        setFakeLoginResponse();
-        setFakeProfileResponse();
-        setFakeGamesResponse();
-
-        ResultActions resultActions = mvc.perform(
-                get("/api/auth/steam/callback/signup")
-                        .params(new LinkedMultiValueMap<>(Collections.singletonMap("openid.mode", List.of("id_res"))))
-                        .params(new LinkedMultiValueMap<>(Collections.singletonMap("openid.claimed_id", List.of("https://steamcommunity.com/openid/id/1234"))))
-                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-        );
-
-        resultActions.andExpect(status().isOk())
-                .andExpect(
-                result -> {
-                    Cookie accessTokenCookie = result.getResponse().getCookie("accessToken");
-                    assertThat(accessTokenCookie).isNotNull();
-                    assertThat(accessTokenCookie.getValue()).isNotBlank();
-                    assertThat(accessTokenCookie.getPath()).isEqualTo("/");
-                    assertThat(accessTokenCookie.isHttpOnly()).isTrue();
-
-                    Cookie apiKeyCookie = result.getResponse().getCookie("apiKey");
-                    assertThat(apiKeyCookie).isNotNull();
-                    assertThat(apiKeyCookie.getValue()).isNotBlank();
-                    assertThat(apiKeyCookie.getPath()).isEqualTo("/");
-                    assertThat(apiKeyCookie.isHttpOnly()).isTrue();
-                }
-        );
-
-        Mockito.verify(mockSteamOpenIdClient).validateSteamId(Mockito.any());
-        Mockito.verify(mockSteamApiClient).getPlayerOwnedGames(eq(apikey),Mockito.any());
-        Mockito.verify(mockSteamApiClient).getPlayerSummaries(eq(apikey),Mockito.any());
+        Mockito.verify(mockSteamOpenIdClient).validateSteamId(any());
     }
 
     @Test
@@ -187,7 +107,7 @@ public class SteamAuthTest {
 
         resultActions.andExpect(status().isConflict());
 
-        Mockito.verify(mockSteamOpenIdClient).validateSteamId(Mockito.any());
+        Mockito.verify(mockSteamOpenIdClient).validateSteamId(any());
     }
 
     @Test
@@ -204,32 +124,7 @@ public class SteamAuthTest {
 
         resultActions.andExpect(status().isNotFound());
 
-        Mockito.verify(mockSteamOpenIdClient).validateSteamId(Mockito.any());
-    }
-
-    @Test
-    @DisplayName("스팀 계정 연동 성공 테스트, noSteamMember")
-    void linkNoSteamMember() throws Exception {
-        long initCount = memberSteamDataRepository.count();
-        setFakeLoginResponse();
-        setFakeGamesResponse();
-
-        MockHttpServletRequestBuilder request = get("/api/auth/steam/callback/link")
-                        .params(new LinkedMultiValueMap<>(Collections.singletonMap("openid.mode", List.of("id_res"))))
-                        .params(new LinkedMultiValueMap<>(Collections.singletonMap("openid.claimed_id", List.of("https://steamcommunity.com/openid/id/1234"))))
-                        .contentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        ResultActions resultActions = testMemberHelper.requestWithUserAuth("noSteamMember", request);
-        Thread.sleep(1000); // 비동기 처리 1초 기다림
-
-        resultActions.andExpect(status().isOk());
-
-        // count 가 3 증가했는지 검증
-        long finalCount = memberSteamDataRepository.count();
-        assertEquals(initCount + 3, finalCount);
-
-        Mockito.verify(mockSteamOpenIdClient).validateSteamId(Mockito.any());
-        Mockito.verify(mockSteamApiClient).getPlayerOwnedGames(eq(apikey),Mockito.any());
+        Mockito.verify(mockSteamOpenIdClient).validateSteamId(any());
     }
 }
 

--- a/src/test/java/com/ll/playon/domain/member/controller/SteamAuthTest.java
+++ b/src/test/java/com/ll/playon/domain/member/controller/SteamAuthTest.java
@@ -220,6 +220,7 @@ public class SteamAuthTest {
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED);
 
         ResultActions resultActions = testMemberHelper.requestWithUserAuth("noSteamMember", request);
+        Thread.sleep(1000); // 비동기 처리 1초 기다림
 
         resultActions.andExpect(status().isOk());
 


### PR DESCRIPTION
1. 소유 게임 조회 로직 비동기로 전환

2. Resilience4j 라이브러리 사용해서 retry, rateLimiter, circuitBreaker 도입


---

# 스팀의 API 제한 (API Key 를 사용하는 해당 부분)

1. 하루 최대 100,000번

2. 5분에 200개? (정확하지는 않음)