### PR TITLE
[FIX] 파티 전체 조회 필터링 버그 수정 및 응답 값들 변경

### DIFF
--- a/src/main/java/com/ll/playon/domain/party/party/dto/PartyDetailMemberDto.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/PartyDetailMemberDto.java
@@ -1,18 +1,27 @@
 package com.ll.playon.domain.party.party.dto;
 
 import com.ll.playon.domain.party.party.entity.PartyMember;
+import java.util.Map;
 import lombok.NonNull;
 
 public record PartyDetailMemberDto(
         long memberId,
 
-        // TODO: 스팀 아바타로 변경할지 고려
+        String username,
+
+        String title,
+
+        String nickname,
+
         @NonNull
         String profileImg
 ) {
-    public PartyDetailMemberDto(PartyMember partyMember) {
+    public PartyDetailMemberDto(PartyMember partyMember, Map<Long, String> titleMap) {
         this(
                 partyMember.getMember().getId(),
+                partyMember.getMember().getUsername(),
+                titleMap.getOrDefault(partyMember.getMember().getId(), ""),
+                partyMember.getMember().getNickname(),
                 partyMember.getMember().getProfileImg()
         );
     }

--- a/src/main/java/com/ll/playon/domain/party/party/dto/PartyMemberIdProfileImgDto.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/PartyMemberIdProfileImgDto.java
@@ -1,0 +1,16 @@
+package com.ll.playon.domain.party.party.dto;
+
+import com.ll.playon.domain.party.party.entity.PartyMember;
+
+public record PartyMemberIdProfileImgDto(
+        long memberId,
+
+        String profileImg
+) {
+    public PartyMemberIdProfileImgDto(PartyMember partyMember) {
+        this(
+                partyMember.getMember().getId(),
+                partyMember.getMember().getProfileImg()
+        );
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/party/dto/response/GetPartyDetailResponse.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/response/GetPartyDetailResponse.java
@@ -3,7 +3,6 @@ package com.ll.playon.domain.party.party.dto.response;
 import com.ll.playon.domain.party.party.dto.PartyDetailMemberDto;
 import com.ll.playon.domain.party.party.dto.PartyDetailTagDto;
 import com.ll.playon.domain.party.party.entity.Party;
-import com.ll.playon.domain.party.party.entity.PartyMember;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,13 +13,6 @@ public record GetPartyDetailResponse(
 
         @NotBlank
         String name,
-
-        @NotBlank
-        String ownerName,
-
-        // TODO: 스팀 아바타로 변경할지 고려
-        @NonNull
-        String ownerProfileImg,
 
         @NonNull
         String description,
@@ -38,13 +30,11 @@ public record GetPartyDetailResponse(
 
         // TODO: 채팅 룸 여기에?
 ) {
-    public GetPartyDetailResponse(Party party, PartyMember owner, List<PartyDetailMemberDto> partyMembers,
+    public GetPartyDetailResponse(Party party, List<PartyDetailMemberDto> partyMembers,
                                   List<PartyDetailTagDto> partyTags) {
         this(
                 party.getId(),
                 party.getName(),
-                owner.getMember().getNickname(),
-                owner.getMember().getProfileImg(),
                 party.getDescription(),
                 party.getPartyAt(),
                 party.getHit(),

--- a/src/main/java/com/ll/playon/domain/party/party/dto/response/GetPartyResponse.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/response/GetPartyResponse.java
@@ -1,7 +1,7 @@
 package com.ll.playon.domain.party.party.dto.response;
 
-import com.ll.playon.domain.party.party.dto.PartyDetailMemberDto;
 import com.ll.playon.domain.party.party.dto.PartyDetailTagDto;
+import com.ll.playon.domain.party.party.dto.PartyMemberIdProfileImgDto;
 import com.ll.playon.domain.party.party.entity.Party;
 import com.ll.playon.domain.party.party.entity.PartyMember;
 import com.ll.playon.domain.party.party.entity.PartyTag;
@@ -19,8 +19,7 @@ public record GetPartyResponse(
         @NonNull
         String description,
 
-        @NonNull
-        String headerImage,
+        long appId,
 
         @NonNull
         LocalDateTime partyAt,
@@ -28,7 +27,7 @@ public record GetPartyResponse(
         int total,
 
         @NonNull
-        List<PartyDetailMemberDto> members,
+        List<PartyMemberIdProfileImgDto> members,
 
         @NonNull
         List<PartyDetailTagDto> partyTags
@@ -40,11 +39,11 @@ public record GetPartyResponse(
                 party.getId(),
                 party.getName(),
                 party.getDescription(),
-                party.getGame().getHeaderImage() != null ? party.getGame().getHeaderImage() : "",
+                party.getGame().getAppid(),
                 party.getPartyAt(),
                 party.getTotal(),
                 memberDtos.stream()
-                        .map(PartyDetailMemberDto::new)
+                        .map(PartyMemberIdProfileImgDto::new)
                         .toList(),
                 tagDtos.stream()
                         .map(tag -> tag.getValue().getKoreanValue())

--- a/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
@@ -48,7 +48,6 @@ public class Party {
     @Setter(AccessLevel.PROTECTED)
     private Long id;
 
-    // TODO : Game 엔티티 개설되면 연결
     @ManyToOne(fetch = FetchType.LAZY)
     private SteamGame game;
 
@@ -97,8 +96,6 @@ public class Party {
     @Setter(AccessLevel.PRIVATE)
     private LocalDateTime modifiedAt;
 
-    // TODO : 파티 룸
-
     @Builder
     public Party(SteamGame game, String name, String description, LocalDateTime partyAt, boolean publicFlag,
                  int minimum,
@@ -134,11 +131,6 @@ public class Party {
         this.publicFlag = request.isPublic();
         this.minimum = request.minimum();
         this.maximum = request.maximum();
-        ;
         this.game = game;
-    }
-
-    public void closeParty() {
-        this.endedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -36,7 +36,7 @@ import com.ll.playon.domain.party.party.validation.PartyValidation;
 import com.ll.playon.domain.party.partyLog.dto.response.GetAllPartyLogResponse;
 import com.ll.playon.domain.party.partyLog.service.PartyLogService;
 import com.ll.playon.domain.title.entity.enums.ConditionType;
-import com.ll.playon.domain.title.repository.MemberTitleService;
+import com.ll.playon.domain.title.service.MemberTitleService;
 import com.ll.playon.domain.title.service.TitleEvaluator;
 import com.ll.playon.global.annotation.PartyOwnerOnly;
 import com.ll.playon.global.exceptions.ErrorCode;

--- a/src/main/java/com/ll/playon/domain/party/party/type/PartyRole.java
+++ b/src/main/java/com/ll/playon/domain/party/party/type/PartyRole.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum PartyRole {
     OWNER("생성자"),
     MEMBER("참여자"),
-    PENDING("대기자");
+    PENDING("대기자"),
+    INVITER("초대자");
 
     private final String value;
 }

--- a/src/main/java/com/ll/playon/domain/party/party/util/PartySortUtils.java
+++ b/src/main/java/com/ll/playon/domain/party/party/util/PartySortUtils.java
@@ -1,5 +1,8 @@
 package com.ll.playon.domain.party.party.util;
 
+import static org.springframework.data.domain.Sort.Order;
+import static org.springframework.data.domain.Sort.by;
+
 import com.ll.playon.domain.party.party.dto.response.GetPartyResponse;
 import com.ll.playon.domain.party.party.entity.Party;
 import com.ll.playon.domain.party.party.entity.PartyMember;
@@ -8,15 +11,32 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.springframework.data.domain.Sort;
 
 public class PartySortUtils {
-    public static Comparator<GetPartyResponse> compare(String orderBy, Map<Long, Party> partyMap, Map<Long, Long> totalCountMap) {
+    public static Sort getSort(String orderBy) {
         return switch (orderBy) {
-            case "popular" -> Comparator.comparing((GetPartyResponse dto) -> partyMap.get(dto.partyId()).getHit()).reversed();
-            case "partyAt" -> Comparator.comparing((GetPartyResponse dto) -> partyMap.get(dto.partyId()).getPartyAt());
-            case "personal" -> Comparator.comparing((GetPartyResponse dto) -> totalCountMap.get(dto.partyId())).reversed();
-            default -> Comparator.comparing((GetPartyResponse dto) -> partyMap.get(dto.partyId()).getCreatedAt()).reversed();
+            case "popular" -> by(Order.desc("hit"), Order.asc("partyAt"));
+            case "partyAt" -> by(Order.asc("partyAt"), Order.desc("createdAt"));
+            case "personal" -> by(Order.desc("createdAt"), Order.asc("partyAt"));
+            default -> by(Order.desc("createdAt"), Order.asc("partyAt"));
         };
+    }
+
+    public static boolean isPersonalSort(String orderBy) {
+        return "personal".equals(orderBy);
+    }
+
+    public static Comparator<GetPartyResponse> compare(String orderBy, Map<Long, Party> partyMap,
+                                                       Map<Long, Long> totalCountMap) {
+        if ("personal".equals(orderBy)) {
+            return Comparator
+                    .comparing((GetPartyResponse dto) -> totalCountMap.getOrDefault(dto.partyId(), 0L))
+                    .reversed()
+                    .thenComparing(dto -> partyMap.get(dto.partyId()).getPartyAt());
+        }
+
+        return null;
     }
 
     public static Map<Long, Party> convertToMap(List<Party> parties) {

--- a/src/main/java/com/ll/playon/domain/party/partyLog/service/PartyLogService.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/service/PartyLogService.java
@@ -29,6 +29,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -93,7 +94,7 @@ public class PartyLogService {
     @ActivePartyMemberOnly
     @Transactional
     public void saveImageUrl(Member actor, long partyId, long logId, String url) {
-        if (url == null) {
+        if (StringUtils.isBlank(url)) {
             return;
         }
 

--- a/src/main/java/com/ll/playon/domain/title/dto/RepresentativeTitleDto.java
+++ b/src/main/java/com/ll/playon/domain/title/dto/RepresentativeTitleDto.java
@@ -1,0 +1,11 @@
+package com.ll.playon.domain.title.dto;
+
+import lombok.NonNull;
+
+public record RepresentativeTitleDto(
+        long memberId,
+
+        @NonNull
+        String title
+) {
+}

--- a/src/main/java/com/ll/playon/domain/title/repository/MemberTitleRepository.java
+++ b/src/main/java/com/ll/playon/domain/title/repository/MemberTitleRepository.java
@@ -1,12 +1,14 @@
 package com.ll.playon.domain.title.repository;
 
 import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.title.dto.RepresentativeTitleDto;
 import com.ll.playon.domain.title.entity.MemberTitle;
 import com.ll.playon.domain.title.entity.Title;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.web.bind.annotation.PathVariable;
 
 public interface MemberTitleRepository extends JpaRepository<MemberTitle, Long> {
     Optional<MemberTitle> findByMemberAndTitle(Member member, Title title);
@@ -16,4 +18,13 @@ public interface MemberTitleRepository extends JpaRepository<MemberTitle, Long> 
     Optional<MemberTitle> findByMemberAndIsRepresentativeTrue(Member member);
 
     Optional<MemberTitle> findByTitleIdAndMember(Long titleId, Member actor);
+
+    @Query("""
+            SELECT NEW com.ll.playon.domain.title.dto.RepresentativeTitleDto(mt.member.id, t.name)
+            FROM MemberTitle mt
+            JOIN mt.title t
+            WHERE mt.isRepresentative = true
+            AND mt.member.id IN :memberIds
+            """)
+    List<RepresentativeTitleDto> findRepresentativeTitleByMemberIds(@PathVariable("memberIds") List<Long> memberIds);
 }


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [ ] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 파티 조회 검색 로직 수정
- 기존 정렬 및 페이징이 제대로 안 되던 버그 발견
- 검색 및 페이징이 되도록 버그 수정
- 이제 정렬 기준이나 값들에 따라 올바른 필터링 가능
- 검색 속도가 좀 느린듯하여, 성능 개선 시급해보임

### 2. 파티 관련 응답 데이터 변경
- 프론트 측 요구에 맞춰 응답 데이터 변경

### 3. `PartyRole` 추가
- 기존은 `Pending` 하나로 대기자를 구분
- 초대받은 사람과 신청한 사람을 추가로 나누기 위해 `Enum` 값 추가
  - `INVITER("초대자")`

### 4. 대표 칭호 조회 추가
- `N+1` 방지를 위해 대표 칭호 조회하는 쿼리 및 코드를 추가