### PR TITLE
[FEAT] 파티 초대 승인/거절 및 AOP 추가

### DIFF
--- a/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
@@ -92,7 +92,7 @@ public class MemberController {
         return RsData.success(HttpStatus.OK, "성공");
     }
 
-    @PostMapping("/me/parties/{partyId}")
+    @PutMapping("/me/parties/{partyId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "파티 초대 승락")
     public void approvePartyInvitation(@PathVariable long partyId) {

--- a/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
@@ -91,4 +91,22 @@ public class MemberController {
         memberService.getUserGamesAndCheckGenres(actor);
         return RsData.success(HttpStatus.OK, "성공");
     }
+
+    @PostMapping("/me/parties/{partyId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "파티 초대 승락")
+    public void approvePartyInvitation(@PathVariable long partyId) {
+        Member actor = this.userContext.getActualActor();
+
+        this.memberService.approvePartyInvitation(actor, partyId);
+    }
+
+    @DeleteMapping("/me/parties/{partyId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "파티 초대 거절")
+    public void rejectPartyInvitation(@PathVariable long partyId) {
+        Member actor = this.userContext.getActualActor();
+
+        this.memberService.rejectPartyInvitation(actor, partyId);
+    }
 }

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -19,7 +19,6 @@ import com.ll.playon.domain.member.repository.MemberRepository;
 import com.ll.playon.domain.member.repository.MemberSteamDataRepository;
 import com.ll.playon.domain.party.party.context.PartyMemberContext;
 import com.ll.playon.domain.party.party.entity.PartyMember;
-import com.ll.playon.domain.party.party.service.PartyService;
 import com.ll.playon.domain.party.party.type.PartyRole;
 import com.ll.playon.domain.title.entity.enums.ConditionType;
 import com.ll.playon.domain.title.service.TitleEvaluator;
@@ -46,7 +45,6 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final AuthTokenService authTokenService;
-    private final PartyService partyService;
     private final UserContext userContext;
     private final SteamAPI steamAPI;
     private final MemberSteamDataRepository memberSteamDataRepository;

--- a/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
@@ -4,6 +4,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 
 import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.party.party.dto.request.PutPartyRequest;
+import com.ll.playon.domain.party.party.type.PartyRole;
 import com.ll.playon.domain.party.party.type.PartyStatus;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -115,16 +116,22 @@ public class Party {
     public void addPartyMember(PartyMember partyMember) {
         this.partyMembers.add(partyMember);
         partyMember.setParty(this);
-        this.total += 1;
+
+        if (partyMember.getPartyRole().equals(PartyRole.OWNER) || partyMember.getPartyRole().equals(PartyRole.MEMBER)) {
+            this.updateTotal(true);
+        }
     }
 
     public void deletePartyMember(PartyMember partyMember) {
+        if (partyMember.getPartyRole().equals(PartyRole.OWNER) || partyMember.getPartyRole().equals(PartyRole.MEMBER)) {
+            this.updateTotal(false);
+        }
+
         this.partyMembers.remove(partyMember);
         partyMember.setParty(null);
-        this.total -= 1;
     }
 
-    public void update(PutPartyRequest request, SteamGame game) {
+    public void updateParty(PutPartyRequest request, SteamGame game) {
         this.name = request.name();
         this.description = request.description() != null ? request.description() : "";
         this.partyAt = request.partyAt();
@@ -132,5 +139,9 @@ public class Party {
         this.minimum = request.minimum();
         this.maximum = request.maximum();
         this.game = game;
+    }
+
+    public void updateTotal(boolean isPlus) {
+        this.total = isPlus ? this.total + 1 : this.total - 1;
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/entity/PartyMember.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/PartyMember.java
@@ -14,7 +14,12 @@ import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(
@@ -65,5 +70,14 @@ public class PartyMember extends BaseTime {
         if (this.party != null) {
             this.party.deletePartyMember(this);
         }
+    }
+
+    public void promoteRole(PartyRole partyRole) {
+        if ((this.partyRole.equals(PartyRole.PENDING) || this.partyRole.equals(PartyRole.INVITER))
+            && (partyRole.equals(PartyRole.OWNER) || partyRole.equals(PartyRole.MEMBER))) {
+            this.party.updateTotal(true);
+        }
+
+        this.partyRole = partyRole;
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -314,7 +314,7 @@ public class PartyService {
         }
 
         // TODO: 유니크 제약 조건 있으면 체크
-        party.update(putPartyRequest, game);
+        party.updateParty(putPartyRequest, game);
 
         this.partyTagService.updatePartyTags(party, putPartyRequest.tags());
 
@@ -387,7 +387,7 @@ public class PartyService {
 
         PartyMember pendingMember = this.getPendingMember(memberId, party);
 
-        pendingMember.setPartyRole(PartyRole.MEMBER);
+        pendingMember.promoteRole(PartyRole.MEMBER);
     }
 
     // 파티 참가 신청 거부
@@ -428,7 +428,7 @@ public class PartyService {
             ErrorCode.IS_ALREADY_PARTY_MEMBER.throwServiceException();
         }
 
-        party.addPartyMember(PartyMemberMapper.of(invitedActor, PartyRole.PENDING));
+        party.addPartyMember(PartyMemberMapper.of(invitedActor, PartyRole.INVITER));
 
         // TODO: 알람?
     }

--- a/src/main/java/com/ll/playon/global/annotation/PartyInviterOnly.java
+++ b/src/main/java/com/ll/playon/global/annotation/PartyInviterOnly.java
@@ -1,0 +1,11 @@
+package com.ll.playon.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PartyInviterOnly {
+}

--- a/src/main/java/com/ll/playon/global/aspect/PartyInviterCheckAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/PartyInviterCheckAspect.java
@@ -1,0 +1,60 @@
+package com.ll.playon.global.aspect;
+
+import com.ll.playon.domain.member.entity.Member;
+import com.ll.playon.domain.party.party.context.PartyContext;
+import com.ll.playon.domain.party.party.context.PartyMemberContext;
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.domain.party.party.repository.PartyMemberRepository;
+import com.ll.playon.domain.party.party.repository.PartyRepository;
+import com.ll.playon.domain.party.party.type.PartyRole;
+import com.ll.playon.global.exceptions.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PartyInviterCheckAspect {
+    private final PartyRepository partyRepository;
+    private final PartyMemberRepository partyMemberRepository;
+
+    @Around("@annotation(com.ll.playon.global.annotation.PartyInviterOnly)")
+    public Object checkPartyInviter(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object[] args = joinPoint.getArgs();
+
+        Member actor = (Member) args[0];
+        Long partyId = (Long) args[1];
+        Party party = this.partyRepository.findById(partyId)
+                .orElseThrow(ErrorCode.PARTY_NOT_FOUND::throwServiceException);
+
+        if (!isNotPartyInviter(actor, party)) {
+            throw ErrorCode.IS_NOT_PARTY_INVITER.throwServiceException();
+        }
+
+        PartyMember partyMember = this.partyMemberRepository.findByMemberAndParty(actor, party)
+                .orElseThrow(ErrorCode.PARTY_MEMBER_NOT_FOUND::throwServiceException);
+
+        PartyContext.setParty(party);
+        PartyMemberContext.setPartyMember(partyMember);
+
+        try {
+            return joinPoint.proceed(args);
+        } finally {
+            PartyContext.clear();
+            PartyMemberContext.clear();
+        }
+    }
+
+    private boolean isNotPartyInviter(Member actor, Party party) {
+        return party.getPartyMembers().stream()
+                .anyMatch(pm -> pm.getPartyRole().equals(PartyRole.INVITER)
+                                && pm.getMember().getId().equals(actor.getId()));
+    }
+}
+

--- a/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
@@ -79,6 +79,7 @@ public enum ErrorCode {
     // PartyMember
     IS_NOT_PARTY_OWNER(HttpStatus.FORBIDDEN, "해당 파티의 파티장이 아닙니다."),
     IS_NOT_PARTY_MEMBER(HttpStatus.FORBIDDEN, "해당 파티의 파티원이 아닙니다."),
+    IS_NOT_PARTY_INVITER(HttpStatus.FORBIDDEN, "해당 파티에 초대되지 않았습니다"),
     IS_NOT_PARTY_MEMBER_OWN(HttpStatus.FORBIDDEN, "파티원 본인이 아닙니다."),
     IS_ALREADY_PARTY_MEMBER(HttpStatus.FORBIDDEN, "이미 해당 파티의 파티원입니다."),
     IS_PARTY_MEMBER_OWN(HttpStatus.FORBIDDEN, "파티원 본인 스스로에 대한 처리는 불가능합니다."),


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. `PartyRole` 에 타입 추가
- `Inviter` 타입을 추가하여 초대 받은 사람을 구분

### 2. 파티 초대 승인
- 파티 초대 승인 기능 추가

### 3. 파티 초대 거절
- 파티 초대 거절 기능 추가

### 4. `Annotation` 및 `AOP` 추가
- `PartyInviterOnly` 어노테이션 추가
- 위를 활용한 `AOP` 를 추가하여, 파티 초대 대상에 한한 인가 진행
  - 서비스 코드 2~3줄로 끝나는 마법

### 5. 엔티티 내부 메서드 방식 사용
- 기존에는  `Setter` 를 이용해 필드 업데이트 진행
- 외부에서의 `Set` 이 좋지 않다고 판단하여, 관련된 엔티티 클래스 내부 메서드들 생성
- 해당 내부 메서드를 사용하여 __참조 객체__를 대상으로 업데이트 진행
- `Setter` 사용 부분이 발견되면 나머지도 변경 예정
