### PR TITLE
[REFACTOR] 파티 상태 변경 및 채팅방 입장 제한

### DIFF
--- a/src/main/java/com/ll/playon/domain/chat/listener/PartyRoomEventListener.java
+++ b/src/main/java/com/ll/playon/domain/chat/listener/PartyRoomEventListener.java
@@ -2,7 +2,7 @@ package com.ll.playon.domain.chat.listener;
 
 import com.ll.playon.domain.chat.dto.ChatMemberCountDto;
 import com.ll.playon.domain.chat.event.ChatRoomDetectedAfterGameStartedEvent;
-import com.ll.playon.domain.chat.policy.PartyRoomDeletePolicy;
+import com.ll.playon.domain.chat.policy.PartyRoomPolicy;
 import com.ll.playon.domain.chat.repository.ChatMemberRepository;
 import com.ll.playon.domain.chat.repository.PartyRoomRepository;
 import com.ll.playon.global.exceptions.ErrorCode;
@@ -37,7 +37,7 @@ public class PartyRoomEventListener {
             Long remainCount = remainCountMap.getOrDefault(partyRoomId, 0L);
 
             try {
-                if (PartyRoomDeletePolicy.shouldDeletePartyRoom(remainCount)) {
+                if (PartyRoomPolicy.shouldDeletePartyRoom(remainCount)) {
                     this.partyRoomRepository.deleteById(partyRoomId);
                     successCount++;
                 }

--- a/src/main/java/com/ll/playon/domain/chat/policy/PartyRoomPolicy.java
+++ b/src/main/java/com/ll/playon/domain/chat/policy/PartyRoomPolicy.java
@@ -7,12 +7,16 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class PartyRoomDeletePolicy {
+public class PartyRoomPolicy {
     public static boolean shouldDeletePartyRoom(long count, Party party) {
         return count == 0 && party.getPartyAt().plusMinutes(5).isBefore(LocalDateTime.now());
     }
 
     public static boolean shouldDeletePartyRoom(long count) {
         return count == 0;
+    }
+
+    public static boolean canEnterPartyRoom(Party party) {
+        return LocalDateTime.now().isAfter(party.getPartyAt().minusMinutes(5));
     }
 }

--- a/src/main/java/com/ll/playon/domain/chat/validation/PartyRoomValidation.java
+++ b/src/main/java/com/ll/playon/domain/chat/validation/PartyRoomValidation.java
@@ -1,0 +1,13 @@
+package com.ll.playon.domain.chat.validation;
+
+import com.ll.playon.domain.chat.policy.PartyRoomPolicy;
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.global.exceptions.ErrorCode;
+
+public class PartyRoomValidation {
+    public static void checkPartyRoomCanEnter(Party party) {
+        if (!PartyRoomPolicy.canEnterPartyRoom(party)) {
+            ErrorCode.PARTY_ROOM_NOT_OPEN.throwServiceException();
+        }
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
@@ -144,4 +144,8 @@ public class Party {
     public void updateTotal(boolean isPlus) {
         this.total = isPlus ? this.total + 1 : this.total - 1;
     }
+
+    public void updatePartyStatus(PartyStatus partyStatus) {
+        this.partyStatus = partyStatus;
+    }
 }

--- a/src/main/java/com/ll/playon/global/aspect/PartyInviterCheckAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/PartyInviterCheckAspect.java
@@ -33,7 +33,7 @@ public class PartyInviterCheckAspect {
         Party party = this.partyRepository.findById(partyId)
                 .orElseThrow(ErrorCode.PARTY_NOT_FOUND::throwServiceException);
 
-        if (!isNotPartyInviter(actor, party)) {
+        if (isNotPartyInviter(actor, party)) {
             throw ErrorCode.IS_NOT_PARTY_INVITER.throwServiceException();
         }
 

--- a/src/main/java/com/ll/playon/global/aspect/PartyOwnerCheckAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/PartyOwnerCheckAspect.java
@@ -29,7 +29,7 @@ public class PartyOwnerCheckAspect {
         Party party = this.partyRepository.findById(partyId)
                 .orElseThrow(ErrorCode.PARTY_NOT_FOUND::throwServiceException);
 
-        if (!isNotPartyOwner(actor, party)) {
+        if (isNotPartyOwner(actor, party)) {
             throw ErrorCode.IS_NOT_PARTY_OWNER.throwServiceException();
         }
 
@@ -44,7 +44,7 @@ public class PartyOwnerCheckAspect {
 
     private boolean isNotPartyOwner(Member actor, Party party) {
         return party.getPartyMembers().stream()
-                .anyMatch(pm -> pm.getPartyRole().equals(PartyRole.OWNER)
+                .noneMatch(pm -> pm.getPartyRole().equals(PartyRole.OWNER)
                                 && pm.getMember().getId().equals(actor.getId()));
     }
 }

--- a/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
@@ -88,6 +88,7 @@ public enum ErrorCode {
     PENDING_PARTY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "파티 참가를 신청한 사용자가 아닙니다."),
 
     // PartyRoom
+    PARTY_ROOM_NOT_OPEN(HttpStatus.FORBIDDEN, "채팅방 입장 가능 시간이 아닙니다. 시작 5분 전부터 입장이 가능합니다"),
     PARTY_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "파티 채팅방이 존재하지 않습니다."),
     PARTY_ROOM_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파티 채팅방 제거에 문제가 생겨 모든 채팅방 제거가 불가능합니다."),
 


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 채팅방 입장 제한 설정
- `partyAt` 시간 __5분 전부터__ 입장 가능

### 2. 정책에 따른 파티 상태 변경
- 첫 입장 시 `PENDING` 상태라면 `ONGOING` 상태로 변경
  - 어차피 5분 동안 아무도 들어오지 않거나, 5분이 지났는데 누군가 들어왔다가 나가면 `COMPLETED` 상태로 변경됨
  - 따라서 스케쥴링으로 메모리 자원을 사용하는 것보다, 처음 채팅창에 진입할 때 `ONGOING` 상태로 변경해주는 것이 보다 효율적이라고 생각하여 이렇게 진행
- 채팅방 퇴장 시 남은 인원이 없으면, 채팅방과 삭제와 함께 `Party` 의 상태도 `COMPLETED` 로 변경

### 3. `PartRoom` 에 대한 `Validation` 분리
- `PartyRoom` 에 대한 `Validation` 을 분리하여 생성 및 사용

### 4. 기존 코드 리팩토링 진행