### PR TITLE
[FIX] 메인용 파티리스트 ProfileImg NPE 해결

### DIFF
--- a/src/main/java/com/ll/playon/domain/party/party/dto/PartyMemberIdProfileImgDto.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/PartyMemberIdProfileImgDto.java
@@ -1,6 +1,7 @@
 package com.ll.playon.domain.party.party.dto;
 
 import com.ll.playon.domain.party.party.entity.PartyMember;
+import java.util.Objects;
 
 public record PartyMemberIdProfileImgDto(
         long memberId,
@@ -10,7 +11,7 @@ public record PartyMemberIdProfileImgDto(
     public PartyMemberIdProfileImgDto(PartyMember partyMember) {
         this(
                 partyMember.getMember().getId(),
-                partyMember.getMember().getProfileImg()
+                Objects.requireNonNullElse(partyMember.getMember().getProfileImg(), "")
         );
     }
 }


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 메인용 파티 리스트 프로필 이미지 `NPE` 해결
- 메인용 파티 리스트의 프로필 이미지 `NPE` 문제 발생 해결