### PR TITLE
[REFACTOR] 파티 리스트 조회 리팩토링

### DIFF
--- a/src/main/java/com/ll/playon/domain/party/party/util/PartySortUtils.java
+++ b/src/main/java/com/ll/playon/domain/party/party/util/PartySortUtils.java
@@ -3,14 +3,6 @@ package com.ll.playon.domain.party.party.util;
 import static org.springframework.data.domain.Sort.Order;
 import static org.springframework.data.domain.Sort.by;
 
-import com.ll.playon.domain.party.party.dto.response.GetPartyResponse;
-import com.ll.playon.domain.party.party.entity.Party;
-import com.ll.playon.domain.party.party.entity.PartyMember;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.springframework.data.domain.Sort;
 
 public class PartySortUtils {
@@ -18,35 +10,8 @@ public class PartySortUtils {
         return switch (orderBy) {
             case "popular" -> by(Order.desc("hit"), Order.asc("partyAt"));
             case "partyAt" -> by(Order.asc("partyAt"), Order.desc("createdAt"));
-            case "personal" -> by(Order.desc("createdAt"), Order.asc("partyAt"));
+            case "personal" -> by(Order.desc("total"), Order.asc("partyAt"));
             default -> by(Order.desc("createdAt"), Order.asc("partyAt"));
         };
     }
-
-    public static boolean isPersonalSort(String orderBy) {
-        return "personal".equals(orderBy);
-    }
-
-    public static Comparator<GetPartyResponse> compare(String orderBy, Map<Long, Party> partyMap,
-                                                       Map<Long, Long> totalCountMap) {
-        if ("personal".equals(orderBy)) {
-            return Comparator
-                    .comparing((GetPartyResponse dto) -> totalCountMap.getOrDefault(dto.partyId(), 0L))
-                    .reversed()
-                    .thenComparing(dto -> partyMap.get(dto.partyId()).getPartyAt());
-        }
-
-        return null;
-    }
-
-    public static Map<Long, Party> convertToMap(List<Party> parties) {
-        return parties.stream()
-                .collect(Collectors.toMap(Party::getId, Function.identity()));
-    }
-
-    public static Map<Long, Long> convertToTotalCountMap(List<PartyMember> partyMembers) {
-        return partyMembers.stream()
-                .collect(Collectors.groupingBy(pm -> pm.getParty().getId(), Collectors.counting()));
-    }
-
 }


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 전체 파티 리스트 조회 코드 리팩토링
- 기존 인원수 정렬 필터링을 이상하게 복잡하게 진행하고 있었음
- `Party` 엔티티의 `total` 필드를 기준으로 정렬하도록 변경
- 그로 인한 코드량 대폭 감소