### PR TITLE
[FIX] 채팅방 Principal NPE 해결

### DIFF
--- a/src/main/java/com/ll/playon/global/webSocket/config/WebSocketConfig.java
+++ b/src/main/java/com/ll/playon/global/webSocket/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.ll.playon.global.webSocket.config;
 
+import com.ll.playon.global.webSocket.security.CustomHandshakeHandler;
 import com.ll.playon.global.webSocket.security.JwtHandshakeInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ import org.springframework.web.socket.config.annotation.WebSocketTransportRegist
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
+    private final CustomHandshakeHandler customHandshakeHandler;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -21,8 +23,16 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 //                .setAllowedOrigins("*")
                 .setAllowedOriginPatterns("*")
                 .addInterceptors(jwtHandshakeInterceptor)
+                .setHandshakeHandler(customHandshakeHandler)
+                .addInterceptors(jwtHandshakeInterceptor)
                 .withSockJS()   // SockJs Fallback
         ;
+
+        registry.addEndpoint("/ws") // 프론트의 WebSocket 연결 주소
+//                .setAllowedOrigins("*")
+                .setAllowedOriginPatterns("*")
+                .setHandshakeHandler(customHandshakeHandler)
+                .addInterceptors(jwtHandshakeInterceptor);
     }
 
     @Override

--- a/src/main/java/com/ll/playon/global/webSocket/security/CustomHandshakeHandler.java
+++ b/src/main/java/com/ll/playon/global/webSocket/security/CustomHandshakeHandler.java
@@ -1,0 +1,28 @@
+package com.ll.playon.global.webSocket.security;
+
+import java.security.Principal;
+import java.util.Map;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+@Component
+public class CustomHandshakeHandler extends DefaultHandshakeHandler {
+    @Override
+    protected Principal determineUser(ServerHttpRequest request, WebSocketHandler wsHandler,
+                                      Map<String, Object> attributes) {
+        Long userId = (Long) attributes.get("userId");
+
+        if (userId == null) {
+            return null;
+        }
+
+        return new Principal() {
+            @Override
+            public String getName() {
+                return userId.toString();
+            }
+        };
+    }
+}


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 채팅방 Principal NPE
- 채팅방에서 `Principa` l이 `null` 로 들어오는 문제 발생
- `DfeaultHandshakeHandler` 를 `WebSocketConfig` 에 추가
- 이전의 `Principal` 정보를 가져올 수 있도록 수정

### 2. JwtHandshakeInterceptor 수정
- `JwtHandshakeInterceptor` 에서 쿠키 뿐만 아니라 `JWT` 값으로도 연동이 가능하도록 설정