### PR TITLE
[FEAT] 파티 신청 취소

### DIFF
--- a/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
@@ -1,7 +1,12 @@
 package com.ll.playon.domain.member.controller;
 
 import com.ll.playon.domain.game.game.dto.GameListResponse;
-import com.ll.playon.domain.member.dto.*;
+import com.ll.playon.domain.member.dto.GetMembersResponse;
+import com.ll.playon.domain.member.dto.MemberAuthRequest;
+import com.ll.playon.domain.member.dto.MemberDetailDto;
+import com.ll.playon.domain.member.dto.MemberProfileResponse;
+import com.ll.playon.domain.member.dto.PresignedUrlResponse;
+import com.ll.playon.domain.member.dto.PutMemberDetailDto;
 import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.member.service.MemberService;
 import com.ll.playon.domain.member.service.SteamAsyncService;
@@ -11,13 +16,21 @@ import com.ll.playon.global.security.UserContext;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/members")
@@ -89,14 +102,25 @@ public class MemberController {
     @Operation(summary = "사용자의 보유게임 갱신")
     public RsData<String> linkSteamGames() {
         Member actor = userContext.getActor();
-        if(ObjectUtils.isEmpty(actor)) throw ErrorCode.UNAUTHORIZED.throwServiceException();
+        if (ObjectUtils.isEmpty(actor)) {
+            throw ErrorCode.UNAUTHORIZED.throwServiceException();
+        }
         steamAsyncService.getUserGamesAndCheckGenres(actor);
         return RsData.success(HttpStatus.OK, "성공");
     }
 
+    @DeleteMapping("/me/parties/pending/{partyId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "파티 신청 취소")
+    public void cancelPendingParty(@PathVariable long partyId) {
+        Member actor = this.userContext.getActualActor();
+
+        this.memberService.cancelPendingParty(actor, partyId);
+    }
+
     @PutMapping("/me/parties/{partyId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @Operation(summary = "파티 초대 승락")
+    @Operation(summary = "파티 초대 승낙")
     public void approvePartyInvitation(@PathVariable long partyId) {
         Member actor = this.userContext.getActualActor();
 

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -316,6 +316,7 @@ public class MemberService {
         Party party = PartyContext.getParty();
 
         PartyValidation.checkPartyCanJoin(party);
+        PartyValidation.checkPartyIsNotFull(party);
 
         PartyMember me = PartyMemberContext.getPartyMember();
 

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -19,6 +19,7 @@ import com.ll.playon.domain.party.party.type.PartyRole;
 import com.ll.playon.domain.title.entity.enums.ConditionType;
 import com.ll.playon.domain.title.service.TitleEvaluator;
 import com.ll.playon.global.annotation.PartyInviterOnly;
+import com.ll.playon.global.annotation.PartyPendingOnly;
 import com.ll.playon.global.aws.s3.S3Service;
 import com.ll.playon.global.exceptions.ErrorCode;
 import com.ll.playon.global.security.UserContext;
@@ -288,6 +289,14 @@ public class MemberService {
         }
 
         return toGameListResponse(ownedGames);
+    }
+
+    @PartyPendingOnly
+    @Transactional
+    public void cancelPendingParty(Member actor, long partyId) {
+        PartyMember me = PartyMemberContext.getPartyMember();
+
+        me.delete();
     }
 
     // 파티 초대 승인

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -353,14 +353,14 @@ public class PartyService {
         if (opPartyMember.isPresent()) {
             PartyMember partyMember = opPartyMember.get();
 
-            // 본인일 경우
-            PartyMemberValidation.checkIsPartyMemberOwn(partyMember, actor);
-
             // 이미 해당 파티에 신청한 경우
-            PartyMemberValidation.checkPendingMember(partyMember);
+            PartyMemberValidation.checkAlreadyPendingMember(partyMember);
 
             // 파티원일 경우
             ErrorCode.IS_ALREADY_PARTY_MEMBER.throwServiceException();
+
+            // 본인일 경우
+            PartyMemberValidation.checkIsPartyMemberOwn(partyMember, actor);
         }
 
         party.addPartyMember(PartyMemberMapper.of(actor, PartyRole.PENDING));
@@ -401,20 +401,20 @@ public class PartyService {
         Member invitedActor = this.memberService.findById(memberId)
                 .orElseThrow(ErrorCode.USER_NOT_REGISTERED::throwServiceException);
 
-        Optional<PartyMember> opPartyMember = this.getPartyMember(actor, party);
+        Optional<PartyMember> opPartyMember = this.getPartyMember(invitedActor, party);
 
         // 이미 해당 파티의 파티원일 경우
         if (opPartyMember.isPresent()) {
             PartyMember partyMember = opPartyMember.get();
 
-            // 본인일 경우
-            PartyMemberValidation.checkIsPartyMemberOwn(partyMember, actor);
-
             // 이미 해당 파티에 신청한 경우
-            PartyMemberValidation.checkPendingMember(partyMember);
+            PartyMemberValidation.checkAlreadyInvitedMember(partyMember);
 
             // 파티원일 경우
             ErrorCode.IS_ALREADY_PARTY_MEMBER.throwServiceException();
+
+            // 본인일 경우
+            PartyMemberValidation.checkIsPartyMemberOwn(partyMember, actor);
         }
 
         party.addPartyMember(PartyMemberMapper.of(invitedActor, PartyRole.INVITER));

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -323,10 +323,9 @@ public class PartyService {
 
     // 파티 참가 신청 리스트 조회
     // AOP에 필요한 파라미터
-    @PartyOwnerOnly
     @Transactional(readOnly = true)
     public GetAllPendingMemberResponse getPartyPendingMembers(Member actor, long partyId) {
-        Party party = PartyContext.getParty();
+        Party party = this.getParty(partyId);
 
         List<PartyMember> partyMembers = party.getPartyMembers().stream()
                 .filter(pm -> pm.getPartyRole().equals(PartyRole.PENDING))
@@ -349,6 +348,7 @@ public class PartyService {
         Party party = this.getParty(partyId);
 
         PartyValidation.checkPartyCanJoin(party);
+        PartyValidation.checkPartyIsNotFull(party);
 
         Optional<PartyMember> opPartyMember = this.getPartyMember(actor, party);
 
@@ -378,6 +378,7 @@ public class PartyService {
         Party party = PartyContext.getParty();
 
         PartyValidation.checkPartyCanJoin(party);
+        PartyValidation.checkPartyIsNotFull(party);
 
         PartyMember pendingMember = this.getPendingMember(memberId, party);
 
@@ -405,6 +406,7 @@ public class PartyService {
         Party party = PartyContext.getParty();
 
         PartyValidation.checkPartyCanJoin(party);
+        PartyValidation.checkPartyIsNotFull(party);
 
         Member invitedActor = this.memberService.findById(memberId)
                 .orElseThrow(ErrorCode.USER_NOT_REGISTERED::throwServiceException);

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -347,6 +347,9 @@ public class PartyService {
     @Transactional
     public void requestParticipation(Member actor, long partyId) {
         Party party = this.getParty(partyId);
+
+        PartyValidation.checkPartyCanJoin(party);
+
         Optional<PartyMember> opPartyMember = this.getPartyMember(actor, party);
 
         // 이미 해당 파티의 파티원일 경우
@@ -374,6 +377,8 @@ public class PartyService {
     public void approveParticipation(Member actor, long partyId, long memberId) {
         Party party = PartyContext.getParty();
 
+        PartyValidation.checkPartyCanJoin(party);
+
         PartyMember pendingMember = this.getPendingMember(memberId, party);
 
         pendingMember.promoteRole(PartyRole.MEMBER);
@@ -398,6 +403,9 @@ public class PartyService {
     @Transactional
     public void inviteParty(Member actor, long partyId, long memberId) {
         Party party = PartyContext.getParty();
+
+        PartyValidation.checkPartyCanJoin(party);
+
         Member invitedActor = this.memberService.findById(memberId)
                 .orElseThrow(ErrorCode.USER_NOT_REGISTERED::throwServiceException);
 

--- a/src/main/java/com/ll/playon/domain/party/party/validation/PartyMemberValidation.java
+++ b/src/main/java/com/ll/playon/domain/party/party/validation/PartyMemberValidation.java
@@ -30,9 +30,16 @@ public class PartyMemberValidation {
     }
 
     // 이미 파티에 신청했는지 확인
-    public static void checkPendingMember(PartyMember partyMember) {
+    public static void checkAlreadyPendingMember(PartyMember partyMember) {
         if (partyMember.getPartyRole().equals(PartyRole.PENDING)) {
             ErrorCode.IS_ALREADY_REQUEST_PARTY.throwServiceException();
+        }
+    }
+
+    // 이미 파티 초대를 보냈는지 확인
+    public static void checkAlreadyInvitedMember(PartyMember partyMember) {
+        if (partyMember.getPartyRole().equals(PartyRole.INVITER)) {
+            ErrorCode.IS_ALREADY_INVITING_PARTY.throwServiceException();
         }
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/validation/PartyMemberValidation.java
+++ b/src/main/java/com/ll/playon/domain/party/party/validation/PartyMemberValidation.java
@@ -25,7 +25,7 @@ public class PartyMemberValidation {
     // 파티멤버가 맞는지 확인
     public static void checkPartyMember(Party party, PartyMember partyMember) {
         if (!party.getPartyMembers().contains(partyMember)) {
-            ErrorCode.IS_NOT_PARTY_MEMBER.throwServiceException();
+            ErrorCode.IS_NOT_PARTY_MEMBER_MEMBER.throwServiceException();
         }
     }
 

--- a/src/main/java/com/ll/playon/domain/party/party/validation/PartyValidation.java
+++ b/src/main/java/com/ll/playon/domain/party/party/validation/PartyValidation.java
@@ -19,4 +19,11 @@ public class PartyValidation {
             ErrorCode.IS_NOT_PARTY_PENDING.throwServiceException();
         }
     }
+
+    // 파티 참여 인원을 넘었는지 확인
+    public static void checkPartyIsNotFull(Party party) {
+        if (party.getTotal() + 1 > party.getMaximum()) {
+            ErrorCode.PARTY_IS_FULL.throwServiceException();
+        }
+    }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/validation/PartyValidation.java
+++ b/src/main/java/com/ll/playon/domain/party/party/validation/PartyValidation.java
@@ -5,10 +5,18 @@ import com.ll.playon.domain.party.party.type.PartyStatus;
 import com.ll.playon.global.exceptions.ErrorCode;
 
 public class PartyValidation {
+
     // 파티가 끝났는지 확인
     public static void checkIsPartyClosed(Party party) {
         if (!party.getPartyStatus().equals(PartyStatus.COMPLETED)) {
             ErrorCode.PARTY_IS_NOT_ENDED.throwServiceException();
+        }
+    }
+
+    // 파티가 참가할 수 있는 상태인지 확인
+    public static void checkPartyCanJoin(Party party) {
+        if (!party.getPartyStatus().equals(PartyStatus.PENDING)) {
+            ErrorCode.IS_NOT_PARTY_PENDING.throwServiceException();
         }
     }
 }

--- a/src/main/java/com/ll/playon/global/annotation/PartyPendingOnly.java
+++ b/src/main/java/com/ll/playon/global/annotation/PartyPendingOnly.java
@@ -1,0 +1,11 @@
+package com.ll.playon.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PartyPendingOnly {
+}

--- a/src/main/java/com/ll/playon/global/aspect/ActivePartyMemberCheckAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/ActivePartyMemberCheckAspect.java
@@ -10,14 +10,12 @@ import com.ll.playon.domain.party.party.repository.PartyRepository;
 import com.ll.playon.domain.party.party.type.PartyRole;
 import com.ll.playon.global.exceptions.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 
 @Aspect
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ActivePartyMemberCheckAspect {

--- a/src/main/java/com/ll/playon/global/aspect/ActivePartyMemberCheckAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/ActivePartyMemberCheckAspect.java
@@ -32,7 +32,7 @@ public class ActivePartyMemberCheckAspect {
                 .orElseThrow(ErrorCode.PARTY_NOT_FOUND::throwServiceException);
 
         if (isNotActivePartyMember(actor, party)) {
-            throw ErrorCode.IS_NOT_PARTY_MEMBER.throwServiceException();
+            throw ErrorCode.IS_NOT_PARTY_MEMBER_MEMBER.throwServiceException();
         }
 
         PartyMember partyMember = this.partyMemberRepository.findByMemberAndParty(actor, party)

--- a/src/main/java/com/ll/playon/global/aspect/PartyInviterCheckAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/PartyInviterCheckAspect.java
@@ -10,14 +10,12 @@ import com.ll.playon.domain.party.party.repository.PartyRepository;
 import com.ll.playon.domain.party.party.type.PartyRole;
 import com.ll.playon.global.exceptions.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 
 @Aspect
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PartyInviterCheckAspect {
@@ -53,7 +51,7 @@ public class PartyInviterCheckAspect {
 
     private boolean isNotPartyInviter(Member actor, Party party) {
         return party.getPartyMembers().stream()
-                .anyMatch(pm -> pm.getPartyRole().equals(PartyRole.INVITER)
+                .noneMatch(pm -> pm.getPartyRole().equals(PartyRole.INVITER)
                                 && pm.getMember().getId().equals(actor.getId()));
     }
 }

--- a/src/main/java/com/ll/playon/global/aspect/PartyInviterCheckAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/PartyInviterCheckAspect.java
@@ -32,7 +32,7 @@ public class PartyInviterCheckAspect {
                 .orElseThrow(ErrorCode.PARTY_NOT_FOUND::throwServiceException);
 
         if (isNotPartyInviter(actor, party)) {
-            throw ErrorCode.IS_NOT_PARTY_INVITER.throwServiceException();
+            throw ErrorCode.IS_NOT_PARTY_MEMBER_INVITER.throwServiceException();
         }
 
         PartyMember partyMember = this.partyMemberRepository.findByMemberAndParty(actor, party)

--- a/src/main/java/com/ll/playon/global/aspect/PartyOwnerCheckAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/PartyOwnerCheckAspect.java
@@ -28,7 +28,7 @@ public class PartyOwnerCheckAspect {
                 .orElseThrow(ErrorCode.PARTY_NOT_FOUND::throwServiceException);
 
         if (isNotPartyOwner(actor, party)) {
-            throw ErrorCode.IS_NOT_PARTY_OWNER.throwServiceException();
+            throw ErrorCode.IS_NOT_PARTY_MEMBER_OWNER.throwServiceException();
         }
 
         PartyContext.setParty(party);

--- a/src/main/java/com/ll/playon/global/aspect/PartyPendingCheckAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/PartyPendingCheckAspect.java
@@ -32,7 +32,7 @@ public class PartyPendingCheckAspect {
                 .orElseThrow(ErrorCode.PARTY_NOT_FOUND::throwServiceException);
 
         if (isNotPartyPending(actor, party)) {
-            throw ErrorCode.IS_NOT_PARTY_PENDING.throwServiceException();
+            throw ErrorCode.IS_NOT_PARTY_MEMBER_PENDING.throwServiceException();
         }
 
         PartyMember partyMember = this.partyMemberRepository.findByMemberAndParty(actor, party)

--- a/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
@@ -79,6 +79,7 @@ public enum ErrorCode {
     IS_NOT_PARTY_PENDING(HttpStatus.FORBIDDEN, "참여 가능한 파티가 아닙니다."),
     IS_ALREADY_REQUEST_PARTY(HttpStatus.FORBIDDEN, "파티 신청이 진행 중입니다."),
     IS_ALREADY_INVITING_PARTY(HttpStatus.FORBIDDEN, "파티 초대가 진행 중입니다."),
+    PARTY_IS_FULL(HttpStatus.FORBIDDEN, "파티 정원이 가득 찼습니다."),
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "파티가 존재하지 않습니다."),
 
     // PartyMember

--- a/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
@@ -76,15 +76,16 @@ public enum ErrorCode {
     GUILD_BOARD_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
 
     // Party
+    IS_NOT_PARTY_PENDING(HttpStatus.FORBIDDEN, "참여 가능한 파티가 아닙니다."),
     IS_ALREADY_REQUEST_PARTY(HttpStatus.FORBIDDEN, "파티 신청이 진행 중입니다."),
     IS_ALREADY_INVITING_PARTY(HttpStatus.FORBIDDEN, "파티 초대가 진행 중입니다."),
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "파티가 존재하지 않습니다."),
 
     // PartyMember
-    IS_NOT_PARTY_OWNER(HttpStatus.FORBIDDEN, "해당 파티의 파티장이 아닙니다."),
-    IS_NOT_PARTY_MEMBER(HttpStatus.FORBIDDEN, "해당 파티의 파티원이 아닙니다."),
-    IS_NOT_PARTY_INVITER(HttpStatus.FORBIDDEN, "해당 파티에 초대되지 않았습니다."),
-    IS_NOT_PARTY_PENDING(HttpStatus.FORBIDDEN, "해당 파티에 가입 신청하지 않았습니다."),
+    IS_NOT_PARTY_MEMBER_OWNER(HttpStatus.FORBIDDEN, "해당 파티의 파티장이 아닙니다."),
+    IS_NOT_PARTY_MEMBER_MEMBER(HttpStatus.FORBIDDEN, "해당 파티의 파티원이 아닙니다."),
+    IS_NOT_PARTY_MEMBER_INVITER(HttpStatus.FORBIDDEN, "해당 파티에 초대되지 않았습니다."),
+    IS_NOT_PARTY_MEMBER_PENDING(HttpStatus.FORBIDDEN, "해당 파티에 가입 신청하지 않았습니다."),
     IS_NOT_PARTY_MEMBER_OWN(HttpStatus.FORBIDDEN, "파티원 본인이 아닙니다."),
     IS_ALREADY_PARTY_MEMBER(HttpStatus.FORBIDDEN, "이미 해당 파티의 파티원입니다."),
     IS_PARTY_MEMBER_OWN(HttpStatus.FORBIDDEN, "파티원 본인 스스로에 대한 처리는 불가능합니다."),

--- a/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
@@ -77,12 +77,14 @@ public enum ErrorCode {
 
     // Party
     IS_ALREADY_REQUEST_PARTY(HttpStatus.FORBIDDEN, "파티 신청이 진행 중입니다."),
+    IS_ALREADY_INVITING_PARTY(HttpStatus.FORBIDDEN, "파티 초대가 진행 중입니다."),
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "파티가 존재하지 않습니다."),
 
     // PartyMember
     IS_NOT_PARTY_OWNER(HttpStatus.FORBIDDEN, "해당 파티의 파티장이 아닙니다."),
     IS_NOT_PARTY_MEMBER(HttpStatus.FORBIDDEN, "해당 파티의 파티원이 아닙니다."),
-    IS_NOT_PARTY_INVITER(HttpStatus.FORBIDDEN, "해당 파티에 초대되지 않았습니다"),
+    IS_NOT_PARTY_INVITER(HttpStatus.FORBIDDEN, "해당 파티에 초대되지 않았습니다."),
+    IS_NOT_PARTY_PENDING(HttpStatus.FORBIDDEN, "해당 파티에 가입 신청하지 않았습니다."),
     IS_NOT_PARTY_MEMBER_OWN(HttpStatus.FORBIDDEN, "파티원 본인이 아닙니다."),
     IS_ALREADY_PARTY_MEMBER(HttpStatus.FORBIDDEN, "이미 해당 파티의 파티원입니다."),
     IS_PARTY_MEMBER_OWN(HttpStatus.FORBIDDEN, "파티원 본인 스스로에 대한 처리는 불가능합니다."),


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 파티 신청 취소
- 파티 신청 취소 기능 구현

### 2. 파티 신청자 구분
- 파티 신청자용  `Annotation` 및 `AOP` 추가
- 파티 신청자인지 인가 체크 진행

### 3. 파티 참가 제한 추가
- `PENDING` 상태인 파티에서만 초대/참여 및 승인 가능
- 거절은 따로 제한 두지 않음

### 4. 파티 신청자 목록 권한 변경
- 모든 유저가 파티 신청자 목록을 볼 수 있도록 변경

### 5. 파티 정원 제한 추가
- 파티 초대/참여 및 승인 시 파티의 정원이 넘지 않도록 제한

### 6. 메서드명 변경
- 어울리지 않는 메서드명 일부 변경