### PR TITLE
[FEAT] 유저 및 내 파티 조회 및 로그가 작성된 파티 조회

### DIFF
--- a/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
@@ -156,7 +156,7 @@ public class MemberController {
     }
 
     @GetMapping("/me/parties/logs")
-    @Operation(summary = "내가 파티 로그를 작성한 적 있는 파티들을 최근에 끝난 순으로 조회")
+    @Operation(summary = "내가 파티 로그를 작성한 적 있는 종료된 파티들을 최근에 끝난 순으로 조회")
     public RsData<PageDto<GetPartyResponse>> getLoggedPartiesByMe(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "6") int pageSize
@@ -177,7 +177,7 @@ public class MemberController {
     }
 
     @GetMapping("/{memberId}/parties/logs")
-    @Operation(summary = "유저가 파티 로그를 작성한 적 있는 파티들을 최근에 끝난 순으로 조회")
+    @Operation(summary = "유저가 파티 로그를 작성한 적 있는 종료된 파티들을 최근에 끝난 순으로 조회")
     public RsData<PageDto<GetPartyResponse>> getLoggedPartiesByMembers(
             @PathVariable long memberId,
             @RequestParam(defaultValue = "1") int page,

--- a/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.member.service.MemberService;
 import com.ll.playon.domain.member.service.SteamAsyncService;
 import com.ll.playon.domain.party.party.dto.response.GetPartyMainResponse;
+import com.ll.playon.domain.party.party.dto.response.GetPartyResponse;
 import com.ll.playon.global.exceptions.ErrorCode;
 import com.ll.playon.global.response.RsData;
 import com.ll.playon.global.security.UserContext;
@@ -156,7 +157,7 @@ public class MemberController {
 
     @GetMapping("/me/parties/logs")
     @Operation(summary = "내가 파티 로그를 작성한 적 있는 파티들을 최근에 끝난 순으로 조회")
-    public RsData<PageDto<GetPartyMainResponse>> getLoggedPartiesByMe(
+    public RsData<PageDto<GetPartyResponse>> getLoggedPartiesByMe(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "6") int pageSize
     ) {
@@ -177,7 +178,7 @@ public class MemberController {
 
     @GetMapping("/{memberId}/parties/logs")
     @Operation(summary = "유저가 파티 로그를 작성한 적 있는 파티들을 최근에 끝난 순으로 조회")
-    public RsData<PageDto<GetPartyMainResponse>> getLoggedPartiesByMembers(
+    public RsData<PageDto<GetPartyResponse>> getLoggedPartiesByMembers(
             @PathVariable long memberId,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "6") int pageSize

--- a/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/playon/domain/member/controller/MemberController.java
@@ -10,9 +10,11 @@ import com.ll.playon.domain.member.dto.PutMemberDetailDto;
 import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.member.service.MemberService;
 import com.ll.playon.domain.member.service.SteamAsyncService;
+import com.ll.playon.domain.party.party.dto.response.GetPartyMainResponse;
 import com.ll.playon.global.exceptions.ErrorCode;
 import com.ll.playon.global.response.RsData;
 import com.ll.playon.global.security.UserContext;
+import com.ll.playon.standard.page.dto.PageDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -142,5 +144,48 @@ public class MemberController {
         Member actor = this.userContext.getActualActor();
 
         this.memberService.rejectPartyInvitation(actor, partyId);
+    }
+
+    @GetMapping("/me/parties")
+    @Operation(summary = "내 참여중인 파티 조회")
+    public RsData<GetPartyMainResponse> getMyParties() {
+        Member actor = this.userContext.getActor();
+
+        return RsData.success(HttpStatus.OK, this.memberService.getMyParties(actor));
+    }
+
+    @GetMapping("/me/parties/logs")
+    @Operation(summary = "내가 파티 로그를 작성한 적 있는 파티들을 최근에 끝난 순으로 조회")
+    public RsData<PageDto<GetPartyMainResponse>> getLoggedPartiesByMe(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "6") int pageSize
+    ) {
+        Member actor = this.userContext.getActor();
+
+        return RsData.success(
+                HttpStatus.OK,
+                new PageDto<>(this.memberService.getPartiesLoggedByMe(actor, page, pageSize)));
+    }
+
+    @GetMapping("/{memberId}/parties")
+    @Operation(summary = "타 유저 참여중인 파티 조회")
+    public RsData<GetPartyMainResponse> getMembersParties(@PathVariable long memberId) {
+        // TODO: 정책 확인
+
+        return RsData.success(HttpStatus.OK, this.memberService.getMembersParties(memberId));
+    }
+
+    @GetMapping("/{memberId}/parties/logs")
+    @Operation(summary = "유저가 파티 로그를 작성한 적 있는 파티들을 최근에 끝난 순으로 조회")
+    public RsData<PageDto<GetPartyMainResponse>> getLoggedPartiesByMembers(
+            @PathVariable long memberId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "6") int pageSize
+    ) {
+        // TODO: 정책 확인
+
+        return RsData.success(
+                HttpStatus.OK,
+                new PageDto<>(this.memberService.getPartiesLoggedByMember(memberId, page, pageSize)));
     }
 }

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -349,7 +349,7 @@ public class MemberService {
         return this.getRecentActiveParty(actor);
     }
 
-    // 내가 파티 로그를 작성한 적 있는 파티들을 최근에 끝난 순으로 조회
+    // 내가 파티 로그를 작성한 적 있는 종료된 파티들을 최근에 끝난 순으로 조회
     @Transactional(readOnly = true)
     public Page<GetPartyResponse> getPartiesLoggedByMe(Member actor, int page, int pageSize) {
         Pageable pageable = PageRequest.of(page - 1, pageSize);
@@ -371,7 +371,7 @@ public class MemberService {
         return this.getRecentActiveParty(actor);
     }
 
-    // 유저가 파티 로그를 작성한 적 있는 파티들을 최근에 끝난 순으로 조회
+    // 유저가 파티 로그를 작성한 적 있는 종료된 파티들을 최근에 끝난 순으로 조회
     @Transactional(readOnly = true)
     public Page<GetPartyResponse> getPartiesLoggedByMember(long memberId, int page, int pageSize) {
         Pageable pageable = PageRequest.of(page - 1, pageSize);

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -352,7 +352,7 @@ public class MemberService {
     // 내가 파티 로그를 작성한 적 있는 파티들을 최근에 끝난 순으로 조회
     @Transactional(readOnly = true)
     public Page<GetPartyMainResponse> getPartiesLoggedByMe(Member actor, int page, int pageSize) {
-        Pageable pageable = PageRequest.of(page, pageSize);
+        Pageable pageable = PageRequest.of(page - 1, pageSize);
         Page<Party> partiesLoggedByMe = this.partyRepository.findMembersRecentCompletedParties(actor.getId(), pageable);
 
         if (partiesLoggedByMe.isEmpty()) {
@@ -373,7 +373,7 @@ public class MemberService {
     // 유저가 파티 로그를 작성한 적 있는 파티들을 최근에 끝난 순으로 조회
     @Transactional(readOnly = true)
     public Page<GetPartyMainResponse> getPartiesLoggedByMember(long memberId, int page, int pageSize) {
-        Pageable pageable = PageRequest.of(page, pageSize);
+        Pageable pageable = PageRequest.of(page - 1, pageSize);
         Member actor = this.getActor(memberId);
 
         Page<Party> partiesLoggedByMember = this.partyRepository.findMembersRecentCompletedParties(actor.getId(),

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -351,9 +351,10 @@ public class MemberService {
 
     // 내가 파티 로그를 작성한 적 있는 파티들을 최근에 끝난 순으로 조회
     @Transactional(readOnly = true)
-    public Page<GetPartyMainResponse> getPartiesLoggedByMe(Member actor, int page, int pageSize) {
+    public Page<GetPartyResponse> getPartiesLoggedByMe(Member actor, int page, int pageSize) {
         Pageable pageable = PageRequest.of(page - 1, pageSize);
-        Page<Party> partiesLoggedByMe = this.partyRepository.findMembersRecentCompletedParties(actor.getId(), pageable);
+        Page<Party> partiesLoggedByMe = this.partyRepository.findMembersRecentCompletedParties(
+                actor.getId(), PartyStatus.COMPLETED, pageable);
 
         if (partiesLoggedByMe.isEmpty()) {
             return new PageImpl<>(Collections.emptyList(), pageable, 0);
@@ -372,12 +373,12 @@ public class MemberService {
 
     // 유저가 파티 로그를 작성한 적 있는 파티들을 최근에 끝난 순으로 조회
     @Transactional(readOnly = true)
-    public Page<GetPartyMainResponse> getPartiesLoggedByMember(long memberId, int page, int pageSize) {
+    public Page<GetPartyResponse> getPartiesLoggedByMember(long memberId, int page, int pageSize) {
         Pageable pageable = PageRequest.of(page - 1, pageSize);
         Member actor = this.getActor(memberId);
 
-        Page<Party> partiesLoggedByMember = this.partyRepository.findMembersRecentCompletedParties(actor.getId(),
-                pageable);
+        Page<Party> partiesLoggedByMember = this.partyRepository.findMembersRecentCompletedParties(
+                actor.getId(), PartyStatus.COMPLETED, pageable);
 
         if (partiesLoggedByMember.isEmpty()) {
             return new PageImpl<>(Collections.emptyList(), pageable, 0);
@@ -425,7 +426,7 @@ public class MemberService {
     }
 
     // 최근 유저에 의해 로그가 작성된 종료된 파티 조회
-    private PageImpl<GetPartyMainResponse> getLoggedPartiesByMembers(Page<Party> partiesLoggedByMe, Pageable pageable) {
+    private PageImpl<GetPartyResponse> getLoggedPartiesByMembers(Page<Party> partiesLoggedByMe, Pageable pageable) {
         List<Long> partyIdsLoggedByMe = partiesLoggedByMe.stream()
                 .map(Party::getId)
                 .toList();
@@ -437,7 +438,7 @@ public class MemberService {
         );
 
         return new PageImpl<>(
-                List.of(new GetPartyMainResponse(mergedList)),
+                mergedList,
                 pageable,
                 partiesLoggedByMe.getTotalElements());
     }

--- a/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
+++ b/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
@@ -101,8 +101,8 @@ public class PartyController {
     }
 
     @GetMapping("/main/completed")
-    @Operation(summary = "메인용 종료된 파티 리스트 조회")
-    public RsData<GetPartyMainResponse> getCompletedPartyMain(@RequestParam(defaultValue = "3") int limit) {
+    @Operation(summary = "메인용 파티 로그가 작성되었고 종료된 파티 리스트 조회")
+    public RsData<GetPartyMainResponse> getCompletedPartyWithLogMain(@RequestParam(defaultValue = "3") int limit) {
         // TODO : 추후 롤백
 //        정책 고민 (회원만 조회 가능하게 할 것인지)
 //        Member actor = this.userContext.getActor();

--- a/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
+++ b/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
@@ -107,7 +107,7 @@ public class PartyController {
 //        정책 고민 (회원만 조회 가능하게 할 것인지)
 //        Member actor = this.userContext.getActor();
 
-        return RsData.success(HttpStatus.OK, this.partyService.getCompletedPartyMain(limit));
+        return RsData.success(HttpStatus.OK, this.partyService.getCompletedPartyWithLogMain(limit));
     }
 
     @GetMapping("/{partyId}")

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyMemberRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyMemberRepository.java
@@ -4,12 +4,11 @@ import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.party.party.entity.Party;
 import com.ll.playon.domain.party.party.entity.PartyMember;
 import com.ll.playon.domain.party.party.type.PartyRole;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
-import java.util.Optional;
 
 public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> {
     Optional<PartyMember> findByMemberAndParty(Member actor, Party party);
@@ -18,31 +17,31 @@ public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> 
 
     // 내가 참여한 파티 ID
     @Query("""
-        SELECT DISTINCT pm.party.id
-        FROM PartyMember pm
-        WHERE pm.member.id = :memberId
-          AND pm.partyRole IN ('OWNER','MEMBER')
-    """)
+                SELECT DISTINCT pm.party.id
+                FROM PartyMember pm
+                WHERE pm.member.id = :memberId
+                  AND pm.partyRole IN ('OWNER','MEMBER')
+            """)
     List<Long> findPartyIdsByMemberId(@Param("memberId") Long memberId);
 
     // 특정 파티 ID 목록에 참여했던 멤버
     @Query("""
-        SELECT DISTINCT pm.member.id
-        FROM PartyMember pm
-        WHERE pm.party.id IN :partyIds
-          AND pm.member.id <> :myId
-          AND pm.partyRole IN ('OWNER','MEMBER')
-    """)
+                SELECT DISTINCT pm.member.id
+                FROM PartyMember pm
+                WHERE pm.party.id IN :partyIds
+                  AND pm.member.id <> :myId
+                  AND pm.partyRole IN ('OWNER','MEMBER')
+            """)
     List<Long> findMemberIdsInPartiesExceptMe(@Param("partyIds") List<Long> partyIds, @Param("myId") Long myId);
 
     // 그 멤버들이 참여한 파티 중에서 내가 참여한 파티 제외
     @Query("""
-        SELECT DISTINCT pm.party.id
-        FROM PartyMember pm
-        WHERE pm.member.id IN :memberIds
-          AND pm.party.id NOT IN :excludePartyIds
-          AND pm.partyRole IN ('OWNER','MEMBER')
-    """)
+                SELECT DISTINCT pm.party.id
+                FROM PartyMember pm
+                WHERE pm.member.id IN :memberIds
+                  AND pm.party.id NOT IN :excludePartyIds
+                  AND pm.partyRole IN ('OWNER','MEMBER')
+            """)
     List<Long> findPartyIdsByMembersExceptPartyIds(
             @Param("memberIds") List<Long> memberIds,
             @Param("excludePartyIds") List<Long> excludePartyIds

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -163,7 +163,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
     @Query("""
             SELECT pm.party
             FROM PartyMember pm
-            JOIN FETCH pm.party p
+            JOIN pm.party p
             WHERE pm.member.id = :memberId
             AND p.publicFlag = true
             ORDER BY p.endedAt DESC

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -153,6 +153,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             SELECT pm.party
             FROM PartyMember pm
             WHERE pm.member.id = :memberId
+            AND pm.party.publicFlag = true
             AND pm.partyRole IN :partyRoles
             AND pm.party.partyStatus != :partyStatus
             """)

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -167,7 +167,10 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             JOIN pm.party p
             WHERE pm.member.id = :memberId
             AND p.publicFlag = true
+            AND p.partyStatus = :partyStatus
+            AND pm.partyLog IS NOT NULL
             ORDER BY p.endedAt DESC
             """)
-    Page<Party> findMembersRecentCompletedParties(@Param("memberId") Long memberId, Pageable pageable);
+    Page<Party> findMembersRecentCompletedParties(@Param("memberId") Long memberId,
+                                                  @Param("partyStatus") PartyStatus partyStatus, Pageable pageable);
 }

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -252,7 +252,7 @@ public class PartyService {
         }
 
         List<Party> partiesWithLog = completedParties.stream()
-                .filter(PartyLogUtils::hasAnyPartyLog)
+                .filter(PartyLogUtils::hasPartyLog)
                 .limit(limit)
                 .toList();
 

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -238,9 +238,9 @@ public class PartyService {
         );
     }
 
-    // 메인용 종료된 파티 조회 (limit 만큼)
+    // 메인용 파티 로그가 작성되었고 종료된 파티 리스트 조회 (limit 만큼)
     @Transactional(readOnly = true)
-    public GetPartyMainResponse getCompletedPartyMain(int limit) {
+    public GetPartyMainResponse getCompletedPartyWithLogMain(int limit) {
         Pageable pageable = PageRequest.of(0, limit * 10);
 
         List<Party> completedParties = this.partyRepository.findRecentCompletedPartiesWithLogs(

--- a/src/main/java/com/ll/playon/domain/party/party/util/PartyMergeUtils.java
+++ b/src/main/java/com/ll/playon/domain/party/party/util/PartyMergeUtils.java
@@ -1,0 +1,30 @@
+package com.ll.playon.domain.party.party.util;
+
+import com.ll.playon.domain.party.party.dto.response.GetPartyResponse;
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.domain.party.party.entity.PartyTag;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class PartyMergeUtils {
+
+    // Party 내부 Join 데이터들 병합
+    public static List<GetPartyResponse> mergePartyWithJoinData(List<Party> parties, List<PartyTag> partyTags,
+                                                          List<PartyMember> partyMembers) {
+        Map<Long, List<PartyTag>> partyTagsMap = partyTags.stream()
+                .collect(Collectors.groupingBy(pt -> pt.getParty().getId()));
+
+        Map<Long, List<PartyMember>> partyMembersMap = partyMembers.stream()
+                .collect(Collectors.groupingBy(pm -> pm.getParty().getId()));
+
+        return parties.stream()
+                .map(party -> new GetPartyResponse(
+                        party,
+                        partyTagsMap.getOrDefault(party.getId(), Collections.emptyList()),
+                        partyMembersMap.getOrDefault(party.getId(), Collections.emptyList())
+                )).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/partyLog/util/PartyLogUtils.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/util/PartyLogUtils.java
@@ -5,7 +5,7 @@ import com.ll.playon.domain.party.party.entity.Party;
 public class PartyLogUtils {
 
     // 파티의 파티로그가 있는지 여부
-    public static boolean hasAnyPartyLog(Party party) {
+    public static boolean hasPartyLog(Party party) {
         return party.getPartyMembers().stream()
                 .anyMatch(pm -> pm.getPartyLog() != null);
     }

--- a/src/main/java/com/ll/playon/domain/party/partyLog/util/PartyLogUtils.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/util/PartyLogUtils.java
@@ -1,0 +1,12 @@
+package com.ll.playon.domain.party.partyLog.util;
+
+import com.ll.playon.domain.party.party.entity.Party;
+
+public class PartyLogUtils {
+
+    // 파티의 파티로그가 있는지 여부
+    public static boolean hasAnyPartyLog(Party party) {
+        return party.getPartyMembers().stream()
+                .anyMatch(pm -> pm.getPartyLog() != null);
+    }
+}


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 내가 참여 중인 파티 조회
- 마이 페이지에서 내가 참여 중인 파티 조회 기능 구현
- `List` 로 감싸서 반환

### 2. 내가 파티 로그를 작성한 적 있는 종료된 파티들을 최근에 끝난 순으로 조회
- 마이 페이지에서 내가 파티 로그를 작성한 적 있는 종료된 파티들을 최근에 끝난 순으로 조회
- 페이징 처리

### 3. 타 유저가 참여 중인 파티 조회
- 타 유저 페이지에서 유저가 참여 중인 파티 조회 기능 구현
- `List` 로 감싸서 반환

### 4. 타 유저가 파티 로그를 작성한 적 있는 종료된 파티들을 최근에 끝난 순으로 조회
- 타 유저 페이지에서 타 유저가 파티 로그를 작성한 적 있는 종료된 파티들을 최근에 끝난 순으로 조회
- 페이징 처리

### 5. 메인용 파티 로그가 작성되었고 종료된 파티 리스트 조회 수정
- 기존 잘못된 필터링이 들어가던 버그 픽스

### 6. 공통적으로 사용되는 Party 관련 메서드 분리
- 기존 `mergePartyWithJoinDto` 가 이번 추가되는 기능들에도 사용됨
- `PartyMergeUtils` 로 분류 후 `static` 메서드로 지정

### 7. 파티 로그 초기 데이터 생성
- `BaseInit` 에 `PartyLog` 가 일부 생성되도록 추가

### 8. 메인용 파티 로그가 작성되었고 종료된 파티 리스트 이름 재정의
- 좀 더 직관적이게 이름을 재정의