### PR TITLE
[REFACTOR] 정책에 따른 파티 조회 가능 여부 변경

### DIFF
--- a/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
@@ -148,4 +148,8 @@ public class Party {
     public void updatePartyStatus(PartyStatus partyStatus) {
         this.partyStatus = partyStatus;
     }
+
+    public void increaseHit() {
+        this.hit += 1;
+    }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -220,8 +220,9 @@ public class PartyService {
         Pageable pageable = PageRequest.of(0, limit);
 
         List<Party> parties = this.partyRepository.findAllByPartyStatusAndPublicFlagTrueOrderByPartyAtAscCreatedAtDesc(
-                PartyStatus.PENDING,
-                pageable);
+                        PartyStatus.PENDING, pageable).stream()
+                .filter(party -> party.getTotal() < party.getMaximum())
+                .toList();
 
         if (parties.isEmpty()) {
             return new GetPartyMainResponse(Collections.emptyList());
@@ -286,7 +287,7 @@ public class PartyService {
 
         Map<Long, String> titleMap = this.memberTitleService.getRepresentativeTitleMap(memberIds);
 
-        List<PartyDetailMemberDto> partyDetailMemberDtos = party.getPartyMembers().stream()
+        List<PartyDetailMemberDto> partyDetailMemberDtos = partyMembers.stream()
                 .map(pm -> new PartyDetailMemberDto(pm, titleMap))
                 .toList();
 
@@ -295,7 +296,7 @@ public class PartyService {
                 .toList();
 
         // 조회수 증가
-        party.setHit(party.getHit() + 1);
+        party.increaseHit();
 
         return new GetPartyDetailResponse(party, partyDetailMemberDtos, partyDetailTagDtos);
     }


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 파티 상세 조회 가능 조건 변경
- 파티 상세 조회 시 신청자, 초대자는 나오지 않도록 수정

### 2. 메인용 파티 리스트 조회 노출 조건 변경
- 인원이 마감된 파티는 노출되지 않도록 변경