### PR TITLE
[FIX] 파티 결과창 조회 버그 수정 및 MVP 포인트 응답에 추가

### DIFF
--- a/src/main/java/com/ll/playon/domain/chat/service/ChatService.java
+++ b/src/main/java/com/ll/playon/domain/chat/service/ChatService.java
@@ -90,6 +90,7 @@ public class ChatService {
         if (PartyRoomPolicy.shouldDeletePartyRoom(remainCount, party)) {
             this.partyRoomRepository.delete(partyRoom);
             party.updatePartyStatus(PartyStatus.COMPLETED);
+            party.updateEndTime();
             return;
         }
 

--- a/src/main/java/com/ll/playon/domain/party/party/dto/PartyDetailMemberDto.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/PartyDetailMemberDto.java
@@ -8,6 +8,8 @@ import lombok.NonNull;
 public record PartyDetailMemberDto(
         long memberId,
 
+        long partyMemberId,
+
         String username,
 
         String title,
@@ -20,6 +22,7 @@ public record PartyDetailMemberDto(
     public PartyDetailMemberDto(PartyMember partyMember, Map<Long, String> titleMap) {
         this(
                 partyMember.getMember().getId(),
+                partyMember.getId(),
                 partyMember.getMember().getUsername(),
                 titleMap.getOrDefault(partyMember.getMember().getId(), ""),
                 partyMember.getMember().getNickname(),

--- a/src/main/java/com/ll/playon/domain/party/party/dto/response/GetCompletedPartyDto.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/response/GetCompletedPartyDto.java
@@ -22,6 +22,8 @@ public record GetCompletedPartyDto(
         @NonNull
         String mvpName,
 
+        int mvpPoint,
+
         @NonNull
         String mvpProfileImg,
 
@@ -45,6 +47,7 @@ public record GetCompletedPartyDto(
                 party.getName(),
                 party.getGame().getName(),
                 mvp.getMember().getNickname(),
+                mvp.getMvpPoint(),
                 mvp.getMember().getProfileImg(),
                 party.getPartyAt(),
                 playTime,

--- a/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
@@ -152,4 +152,8 @@ public class Party {
     public void increaseHit() {
         this.hit += 1;
     }
+
+    public void updateEndTime() {
+        this.endedAt = LocalDateTime.now();
+    }
 }


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 파티 종료 버그 수정
- 파티 종료 시 종료 시간을 반영하지 않던 버그 수정
- 정상적으로 파티가 종료되면 종료 시간 반영

### 2. 파티 결과창 조회 버그 수정
- 1번의 버그로 인해 `Party` 엔티티의 `endedAt` 이 `Null` 로 유지
- 이로 인한 `NPE` 발생
- 1번을 해결해줌으로 `NPE` 해결

### 3. 파티 결과창 응답값 수정
- `MVP` 포인트도 같이 응답하도록 추가