### PR TITLE
[REFACTOR] 파티 리스트 조회 시 인원이 가득 찬 파티는 리스트에 비노출

### DIFF
--- a/src/main/java/com/ll/playon/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/ll/playon/domain/chat/controller/ChatController.java
@@ -25,9 +25,7 @@ public class ChatController {
     @PostMapping("/enter/{partyId}")
     @Operation(summary = "채팅방 입장")
     public RsData<GetChatRoomResponse> enterPartyRoom(@PathVariable long partyId) {
-        // TODO: 배포 시 주석 해제, @RequestHeader 삭제
         Member actor = this.userContext.getActualActor();
-//        Member actor = this.userContext.findById(userId);
 
         return RsData.success(HttpStatus.OK, this.chatService.enterPartyRoom(actor, partyId));
     }
@@ -36,9 +34,7 @@ public class ChatController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "채팅방 퇴장")
     public void leavePartyRoom(@PathVariable long partyId) {
-        // TODO: 배포 시 주석 해제
         Member actor = this.userContext.getActualActor();
-//        Member actor = this.userContext.findById(userId);
 
         this.chatService.leavePartyRoom(actor, partyId);
     }

--- a/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
+++ b/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
@@ -52,9 +52,6 @@ public class PartyController {
             @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime partyAt,
             @RequestBody @Valid GetAllPartiesRequest getAllPartiesRequest
     ) {
-        // TODO : 추후 롤백
-//        정책 고민 (회원만 조회 가능하게 할 것인지)
-//        Member actor = this.userContext.getActor();
         Member actor = this.userContext.getActualActor();
 
         GlobalValidation.checkPageSize(pageSize);
@@ -67,10 +64,6 @@ public class PartyController {
     @GetMapping("/{partyId}/result")
     @Operation(summary = "파티 결과 조회")
     public RsData<GetPartyResultResponse> getPartyResult(@PathVariable long partyId) {
-        // TODO : 추후 롤백
-//        정책 고민 (회원만 조회 가능하게 할 것인지)
-//        Member actor = this.userContext.getActor();
-//        Member actor = this.userContext.findById(5L);
 
         return RsData.success(HttpStatus.OK, this.partyService.getPartyResult(partyId));
     }
@@ -78,10 +71,6 @@ public class PartyController {
     @GetMapping("/main/pending")
     @Operation(summary = "메인용 진행 예정 리스트 조회")
     public RsData<GetPartyMainResponse> getPendingPartyMain(@RequestParam(defaultValue = "2") int limit) {
-        // TODO : 추후 롤백
-//        정책 고민 (회원만 조회 가능하게 할 것인지)
-//        Member actor = this.userContext.getActor();
-//        Member actor = this.userContext.findById(5L);
 
         return RsData.success(HttpStatus.OK, this.partyService.getPendingPartyMain(limit));
     }
@@ -89,9 +78,6 @@ public class PartyController {
     @GetMapping("/main/completed")
     @Operation(summary = "메인용 파티 로그가 작성되었고 종료된 파티 리스트 조회")
     public RsData<GetPartyMainResponse> getCompletedPartyWithLogMain(@RequestParam(defaultValue = "3") int limit) {
-        // TODO : 추후 롤백
-//        정책 고민 (회원만 조회 가능하게 할 것인지)
-//        Member actor = this.userContext.getActor();
 
         return RsData.success(HttpStatus.OK, this.partyService.getCompletedPartyWithLogMain(limit));
     }
@@ -99,9 +85,6 @@ public class PartyController {
     @GetMapping("/{partyId}")
     @Operation(summary = "파티 상세 정보 조회")
     public RsData<GetPartyDetailResponse> getPartyDetail(@PathVariable long partyId) {
-        // TODO : 추후 롤백
-//        정책 고민 (회원만 조회 가능하게 할 것인지)
-//        Member actor = this.userContext.getActor();
 
         return RsData.success(HttpStatus.OK, this.partyService.getPartyDetail(partyId));
     }
@@ -110,8 +93,6 @@ public class PartyController {
     @Operation(summary = "파티 수정")
     public RsData<PutPartyResponse> updateParty(@PathVariable long partyId,
                                                 @RequestBody @Valid PutPartyRequest putPartyRequest) {
-        // TODO : 추후 롤백
-//        Member actor = this.userContext.getActor();
         Member actor = this.userContext.getActualActor();
 
         return RsData.success(HttpStatus.OK, this.partyService.updateParty(actor, partyId, putPartyRequest));
@@ -121,8 +102,6 @@ public class PartyController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "파티 취소")
     public void deleteParty(@PathVariable long partyId) {
-        // TODO : 추후 롤백
-//        Member actor = this.userContext.getActor();
         Member actor = this.userContext.getActualActor();
 
         this.partyService.deleteParty(actor, partyId);
@@ -132,8 +111,6 @@ public class PartyController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "파티 신청")
     public void requestParticipation(@PathVariable long partyId) {
-        // TODO : 추후 롤백
-//        Member actor = this.userContext.getActor();
         Member actor = this.userContext.getActualActor();
 
         this.partyService.requestParticipation(actor, partyId);
@@ -143,8 +120,6 @@ public class PartyController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "파티 신청 수락")
     public void approveParticipation(@PathVariable long partyId, @PathVariable long memberId) {
-        // TODO : 추후 롤백
-//        Member actor = this.userContext.getActor();
         Member actor = this.userContext.getActualActor();
 
         this.partyService.approveParticipation(actor, partyId, memberId);
@@ -157,8 +132,6 @@ public class PartyController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "파티 신청 거부")
     public void rejectParticipation(@PathVariable long partyId, @PathVariable long memberId) {
-        // TODO : 추후 롤백
-//        Member actor = this.userContext.getActor();
         Member actor = this.userContext.getActualActor();
 
         this.partyService.rejectParticipation(actor, partyId, memberId);
@@ -167,8 +140,6 @@ public class PartyController {
     @GetMapping("/{partyId}/pending")
     @Operation(summary = "파티 신청자 목록 확인")
     public RsData<GetAllPendingMemberResponse> getPartyPendingMembers(@PathVariable long partyId) {
-        // TODO : 추후 롤백
-//        Member actor = this.userContext.getActor();
         Member actor = this.userContext.getActualActor();
 
         return RsData.success(HttpStatus.OK, this.partyService.getPartyPendingMembers(actor, partyId));
@@ -178,8 +149,6 @@ public class PartyController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "파티 초대")
     public void inviteParty(@PathVariable long partyId, @PathVariable long memberId) {
-        // TODO : 추후 롤백
-//        Member actor = this.userContext.getActor();
         Member actor = this.userContext.getActualActor();
 
         this.partyService.inviteParty(actor, partyId, memberId);

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -25,6 +25,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             AND p.publicFlag = true
             AND (:partyAt IS NULL OR p.partyAt >= :partyAt)
             AND p.id NOT IN :excludedIds
+            AND p.total < p.maximum
             AND (1=:noTagCondition OR p.id IN (
                 SELECT pt.party.id
                 FROM PartyTag pt

--- a/src/main/java/com/ll/playon/domain/party/partyLog/controller/PartyLogController.java
+++ b/src/main/java/com/ll/playon/domain/party/partyLog/controller/PartyLogController.java
@@ -28,7 +28,6 @@ public class PartyLogController {
     @Operation(summary = "파티 로그 작성")
     public RsData<PartyLogResponse> createPartyLog(@PathVariable long partyId,
                                                    @RequestBody @Valid PostPartyLogRequest request) {
-        // TODO : 추후 롤백
         Member actor = this.userContext.getActualActor();
 
         return RsData.success(HttpStatus.CREATED, this.partyLogService.createPartyLog(actor, partyId, request));
@@ -38,7 +37,6 @@ public class PartyLogController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "스크린샷 URL 저장")
     public void saveImageUrl(@PathVariable long logId, @PathVariable long partyId, @RequestBody PostImageUrlRequest request) {
-        // TODO : 추후 롤백
         Member actor = this.userContext.getActualActor();
 
         this.partyLogService.saveImageUrl(actor, partyId, logId, request);
@@ -47,9 +45,6 @@ public class PartyLogController {
     @GetMapping("/party/{partyId}")
     @Operation(summary = "파티의 모든 파티 로그 조회")
     public RsData<GetAllPartyLogResponse> getAllPartyLogs(@PathVariable long partyId) {
-        // TODO : 추후 롤백
-//        Member actor = this.userContext.getActor();
-
         return RsData.success(HttpStatus.OK, this.partyLogService.getAllPartyLogs(partyId));
     }
 
@@ -58,7 +53,6 @@ public class PartyLogController {
     public RsData<PartyLogResponse> updatePartyLog(@PathVariable long logId,
                                                    @PathVariable long partyId,
                                                    @RequestBody @Valid PutPartyLogRequest request) {
-        // TODO : 추후 롤백
         Member actor = this.userContext.getActualActor();
 
         return RsData.success(HttpStatus.OK, this.partyLogService.updatePartyLog(actor, partyId, logId, request));
@@ -68,7 +62,6 @@ public class PartyLogController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "파티 로그 삭제")
     public void deletePartyLog(@PathVariable long logId, @PathVariable long partyId) {
-        // TODO : 추후 롤백
         Member actor = this.userContext.getActualActor();
 
         this.partyLogService.deletePartyLog(actor, partyId, logId);


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 파티 리스트 조회 정책에 따른 수정
- 인원이 가득 찬 파티 리스트는 노출시키지 않도록 수정

### 2. 컨트롤러 주석부 삭제
- `TODO` 로 주석처리한 코드상 불필요한 부분 삭제