### PR TITLE
[FIX] 파티 메인에서 limit 만큼의 페이지를 가져오지 못하는 버그 수정

### DIFF
--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -96,8 +96,15 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
 
     Page<Party> findByGame(SteamGame game, Pageable pageable);
 
-    List<Party> findAllByPartyStatusAndPublicFlagTrueOrderByPartyAtAscCreatedAtDesc(PartyStatus partyStatus,
-                                                                                    Pageable pageable);
+    @Query("""
+            SELECT p
+            FROM Party p
+            WHERE p.partyStatus = :partyStatus
+            AND p.publicFlag = true
+            AND p.total < p.maximum
+            ORDER BY p.partyAt ASC, p.createdAt DESC
+            """)
+    List<Party> findAllPublicPartyUpToLimit(@Param("partyStatus") PartyStatus partyStatus, Pageable pageable);
 
     @Query("""
             SELECT p

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -219,10 +219,7 @@ public class PartyService {
     public GetPartyMainResponse getPendingPartyMain(int limit) {
         Pageable pageable = PageRequest.of(0, limit);
 
-        List<Party> parties = this.partyRepository.findAllByPartyStatusAndPublicFlagTrueOrderByPartyAtAscCreatedAtDesc(
-                        PartyStatus.PENDING, pageable).stream()
-                .filter(party -> party.getTotal() < party.getMaximum())
-                .toList();
+        List<Party> parties = this.partyRepository.findAllPublicPartyUpToLimit(PartyStatus.PENDING, pageable);
 
         if (parties.isEmpty()) {
             return new GetPartyMainResponse(Collections.emptyList());


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 메인 파티 리스트 조회 버그 수정
- 메인 파티 리스트 조회 시 `limit` 만큼의 개수를 원할하게 가져오지 못하는 버그 수정