### PR TITLE
[FEAT] 파티 리스트 조회 맥 조건 추가

### DIFF
--- a/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
+++ b/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
@@ -5,7 +5,13 @@ import com.ll.playon.domain.member.service.MemberService;
 import com.ll.playon.domain.party.party.dto.request.GetAllPartiesRequest;
 import com.ll.playon.domain.party.party.dto.request.PostPartyRequest;
 import com.ll.playon.domain.party.party.dto.request.PutPartyRequest;
-import com.ll.playon.domain.party.party.dto.response.*;
+import com.ll.playon.domain.party.party.dto.response.GetAllPendingMemberResponse;
+import com.ll.playon.domain.party.party.dto.response.GetPartyDetailResponse;
+import com.ll.playon.domain.party.party.dto.response.GetPartyMainResponse;
+import com.ll.playon.domain.party.party.dto.response.GetPartyResponse;
+import com.ll.playon.domain.party.party.dto.response.GetPartyResultResponse;
+import com.ll.playon.domain.party.party.dto.response.PostPartyResponse;
+import com.ll.playon.domain.party.party.dto.response.PutPartyResponse;
 import com.ll.playon.domain.party.party.service.PartyService;
 import com.ll.playon.domain.title.entity.enums.ConditionType;
 import com.ll.playon.domain.title.service.TitleEvaluator;
@@ -16,13 +22,21 @@ import com.ll.playon.standard.page.dto.PageDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDateTime;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -48,6 +62,7 @@ public class PartyController {
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int pageSize,
             @RequestParam(defaultValue = "latest") String orderBy,
+            @RequestParam(defaultValue = "false") boolean isMacSupported,
             @RequestParam(value = "partyAt", required = false)
             @DateTimeFormat(iso = ISO.DATE_TIME) LocalDateTime partyAt,
             @RequestBody @Valid GetAllPartiesRequest getAllPartiesRequest
@@ -57,8 +72,8 @@ public class PartyController {
         GlobalValidation.checkPageSize(pageSize);
 
         return RsData.success(HttpStatus.OK,
-                new PageDto<>(this.partyService.getAllFilteredParties(actor, page, pageSize, orderBy, partyAt,
-                        getAllPartiesRequest)));
+                new PageDto<>(this.partyService.getAllFilteredParties(actor, page, pageSize, orderBy,
+                        isMacSupported, partyAt, getAllPartiesRequest)));
     }
 
     @GetMapping("/{partyId}/result")

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -26,6 +26,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             AND (:partyAt IS NULL OR p.partyAt >= :partyAt)
             AND p.id NOT IN :excludedIds
             AND p.total < p.maximum
+            AND (:isMacSupported = false OR p.game.isMacSupported = :isMacSupported)
             AND (1=:noTagCondition OR p.id IN (
                 SELECT pt.party.id
                 FROM PartyTag pt
@@ -43,9 +44,10 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
                 HAVING COUNT(g.name) = :genreSize
             ))
             """)
-    Page<Long> findPartyIdsByAllConditions(
+    Page<Long> findPartyIdsWithAllFilter(
             @Param("excludedIds") List<Long> excludedIds,
             @Param("partyAt") LocalDateTime partyAt,
+            @Param("isMacSupported") boolean isMacSupported,
             @Param("tagValues") List<String> tagValues,
             @Param("tagSize") long tagSize,
             @Param("noTagCondition") int noTagCondition,

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -24,7 +24,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             WHERE p.partyStatus = 'PENDING'
             AND p.publicFlag = true
             AND (:partyAt IS NULL OR p.partyAt >= :partyAt)
-            AND p.id NOT IN :excludedIds
+            AND (:excludedIds IS NULL OR p.id NOT IN :excludedIds)
             AND p.total < p.maximum
             AND (:isMacSupported = false OR p.game.isMacSupported = :isMacSupported)
             AND (1=:noTagCondition OR p.id IN (

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -139,7 +139,7 @@ public class PartyService {
 
         // 내 파티 ID 제외 + 공개 파티 ID 조회
         Page<Long> partyIds = this.partyRepository.findPartyIdsWithAllFilter(
-                myPartyIds.isEmpty() ? Collections.singletonList(-1L) : myPartyIds,
+                myPartyIds.isEmpty() ? null : myPartyIds,
                 partyAt,
                 isMacSupported,
                 tagValues,

--- a/src/main/java/com/ll/playon/global/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/ll/playon/global/security/CustomAuthenticationFilter.java
@@ -72,7 +72,7 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        if (PUBLIC_URLS.stream().anyMatch(pattern -> pathMatcher.match(pattern, uri))) {
+        if (PUBLIC_URLS.stream().anyMatch(pattern -> pathMatcher.match(pattern, uri)) && !pathMatcher.match("/api/parties/list", uri)) {
             filterChain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 파티 리스트 조회 조건 추가
- `isMacSupported` 검색 조건 추가
- defaultValue` 는 `false` 이고, 이 때는 이 조건과 상관 없이 전체 리스트 조회
- `true` 이면 `SteamGame` 의 `IsMacSupported` 가 `true` 인 것 만 조회