### PR TITLE
[FIX] 파티 생성 및 리스트 조회 시 appId 사용

### DIFF
--- a/src/main/java/com/ll/playon/domain/game/game/repository/GameRepository.java
+++ b/src/main/java/com/ll/playon/domain/game/game/repository/GameRepository.java
@@ -2,21 +2,31 @@ package com.ll.playon.domain.game.game.repository;
 
 import com.ll.playon.domain.game.game.dto.request.GameSearchCondition;
 import com.ll.playon.domain.game.game.entity.SteamGame;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
-
-import java.util.List;
 
 @Repository
 public interface GameRepository extends JpaRepository<SteamGame, Long>, GameRepositoryCustom {
     List<SteamGame> findAllByAppidIn(List<Long> appIds);
+
     Optional<SteamGame> findByAppid(Long appid);
+
     Optional<SteamGame> findSteamGameByAppid(Long appid);
+
     List<SteamGame> searchByGameName(String keyword);
+
     Page<SteamGame> searchGames(GameSearchCondition condition, Pageable pageable);
+
     List<SteamGame> findAllByIdIn(List<Long> gameIds);
+
+    @Query("""
+            SELECT s.appid
+            FROM SteamGame s
+            """)
+    Page<Long> findAllAppIds(Pageable pageable);
 }

--- a/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
+++ b/src/main/java/com/ll/playon/domain/party/party/controller/PartyController.java
@@ -1,7 +1,6 @@
 package com.ll.playon.domain.party.party.controller;
 
 import com.ll.playon.domain.member.entity.Member;
-import com.ll.playon.domain.member.service.MemberService;
 import com.ll.playon.domain.party.party.dto.request.GetAllPartiesRequest;
 import com.ll.playon.domain.party.party.dto.request.PostPartyRequest;
 import com.ll.playon.domain.party.party.dto.request.PutPartyRequest;
@@ -46,7 +45,6 @@ public class PartyController {
     private final PartyService partyService;
     private final UserContext userContext;
     private final TitleEvaluator titleEvaluator;
-    private final MemberService memberService;
 
     @PostMapping
     @Operation(summary = "파티 생성")

--- a/src/main/java/com/ll/playon/domain/party/party/dto/request/GetAllPartiesRequest.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/request/GetAllPartiesRequest.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.springframework.util.CollectionUtils;
 
 public record GetAllPartiesRequest(
-        Long gameId,
+        Long appId,
 
         List<String> genres,
 

--- a/src/main/java/com/ll/playon/domain/party/party/dto/request/PostPartyRequest.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/request/PostPartyRequest.java
@@ -27,7 +27,7 @@ public record PostPartyRequest(
         Integer maximum,
 
         @NotNull
-        Long gameId,
+        Long appId,
 
         @NotNull(message = "태그 정보들을 입력해주세요.")
         List<@Valid PartyTagRequest> tags

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -34,8 +34,8 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
                 GROUP BY pt.party.id
                 HAVING COUNT(pt.value) = :tagSize
             ))
-            AND (:gameId IS NULL OR p.game.id = :gameId)
-            AND (:genres IS NULL OR p.game.id IN (
+            AND (:appId IS NULL OR p.game.appid = :appId)
+            AND (:genres IS NULL OR p.game.appid IN (
                 SELECT sg.id
                 FROM SteamGame sg
                 JOIN sg.genres g
@@ -50,7 +50,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             @Param("isMacSupported") boolean isMacSupported,
             @Param("tagValues") List<String> tagValues,
             @Param("tagSize") int tagSize,
-            @Param("gameId") Long gameId,
+            @Param("appId") Long appId,
             @Param("genres") List<String> genres,
             @Param("genreSize") int genreSize,
             Pageable pageable

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -78,7 +78,7 @@ public class PartyService {
     // 파티 생성
     @Transactional
     public PostPartyResponse createParty(Member actor, PostPartyRequest request) {
-        SteamGame game = this.gameRepository.findById(request.gameId())
+        SteamGame game = this.gameRepository.findByAppid(request.appId())
                 .orElseThrow(ErrorCode.GAME_NOT_FOUND::throwServiceException);
 
         Party party = PartyMapper.of(request, game);
@@ -145,7 +145,7 @@ public class PartyService {
                 isMacSupported,
                 tagValues,
                 tagSize,
-                request.gameId(),
+                request.appId(),
                 genres,
                 genreSize,
                 pageable

--- a/src/main/java/com/ll/playon/global/initData/BaseInitData.java
+++ b/src/main/java/com/ll/playon/global/initData/BaseInitData.java
@@ -9,7 +9,11 @@ import com.ll.playon.domain.board.repository.BoardLikeRepository;
 import com.ll.playon.domain.board.repository.BoardRepository;
 import com.ll.playon.domain.chat.entity.PartyRoom;
 import com.ll.playon.domain.chat.repository.PartyRoomRepository;
-import com.ll.playon.domain.game.game.entity.*;
+import com.ll.playon.domain.game.game.entity.SteamGame;
+import com.ll.playon.domain.game.game.entity.SteamGenre;
+import com.ll.playon.domain.game.game.entity.SteamImage;
+import com.ll.playon.domain.game.game.entity.SteamMovie;
+import com.ll.playon.domain.game.game.entity.WeeklyPopularGame;
 import com.ll.playon.domain.game.game.repository.GameRepository;
 import com.ll.playon.domain.game.game.repository.WeeklyGameRepository;
 import com.ll.playon.domain.guild.guild.entity.Guild;
@@ -48,6 +52,19 @@ import com.ll.playon.domain.title.repository.TitleRepository;
 import com.ll.playon.global.type.TagType;
 import com.ll.playon.global.type.TagValue;
 import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationRunner;
@@ -55,13 +72,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.*;
-import java.util.stream.Collectors;
 
 
 @Configuration
@@ -442,9 +453,7 @@ public class BaseInitData {
 
         Map<Long, Member> memberMap = owners.stream().collect(Collectors.toMap(Member::getId, m -> m));
         List<TagType> tagTypes = new ArrayList<>(List.of(TagType.values()));
-        List<SteamGame> steamGames = this.gameRepository.findAll(
-                PageRequest.of(0, 100, Sort.by(Sort.Direction.DESC, "id"))
-        ).getContent();
+        List<Long> steamAppIds = this.gameRepository.findAllAppIds(PageRequest.of(0, 30)).getContent();
 
         Random random = new Random();
 
@@ -456,7 +465,9 @@ public class BaseInitData {
                 boolean isPublic = random.nextBoolean();
                 int minimum = random.nextInt(2, 10);
                 int maximum = random.nextInt(10, 51);
-                SteamGame steamGame = steamGames.get(random.nextInt(steamGames.size()));
+
+                Long randomAppId = steamAppIds.get(random.nextInt(steamAppIds.size()));
+                SteamGame steamGame = this.gameRepository.findByAppid(randomAppId).get();
 
                 Party party = Party.builder()
                         .name(randomName)

--- a/src/test/java/com/ll/playon/domain/game/controller/GameControllerTest.java
+++ b/src/test/java/com/ll/playon/domain/game/controller/GameControllerTest.java
@@ -204,7 +204,7 @@ public class GameControllerTest {
 
         PartyLog log = partyLogRepository.save(PartyLog.builder()
                 .partyMember(member)
-                .comment("Good gameId")
+                .comment("Good appId")
                 .content("Enjoyed it")
                 .build());
 


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 파티에 사용되는 Game Id 변경
- 기존에는 `SteamGame` 의 기본 키 `id` 를 사용
- 파티 생성 및 파티 리스트 조회에서 `SteamGame` 의 `appId` 를 사용하도록 변경