### PR TITLE
[FIX] 채팅 정책 반영 및 인가 AOP 진행

### DIFF
--- a/src/main/java/com/ll/playon/domain/chat/context/ChatMemberContext.java
+++ b/src/main/java/com/ll/playon/domain/chat/context/ChatMemberContext.java
@@ -1,0 +1,21 @@
+package com.ll.playon.domain.chat.context;
+
+import com.ll.playon.domain.chat.entity.ChatMember;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChatMemberContext {
+    private static final ThreadLocal<ChatMember> currentChatMember = new ThreadLocal<>();
+
+    public static ChatMember getChatMember() {
+        return currentChatMember.get();
+    }
+
+    public static void setChatMember(ChatMember chatMember) {
+        currentChatMember.set(chatMember);
+    }
+
+    public static void clear() {
+        currentChatMember.remove();
+    }
+}

--- a/src/main/java/com/ll/playon/domain/chat/context/PartyRoomContext.java
+++ b/src/main/java/com/ll/playon/domain/chat/context/PartyRoomContext.java
@@ -1,0 +1,21 @@
+package com.ll.playon.domain.chat.context;
+
+import com.ll.playon.domain.chat.entity.PartyRoom;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PartyRoomContext {
+    private static final ThreadLocal<PartyRoom> currentPartyRoom = new ThreadLocal<>();
+
+    public static PartyRoom getPartyRoom() {
+        return currentPartyRoom.get();
+    }
+
+    public static void setPartyRoom(PartyRoom partyRoom) {
+        currentPartyRoom.set(partyRoom);
+    }
+
+    public static void clear() {
+        currentPartyRoom.remove();
+    }
+}

--- a/src/main/java/com/ll/playon/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/ll/playon/domain/chat/controller/ChatMessageController.java
@@ -21,13 +21,6 @@ public class ChatMessageController {
     public void handleMessage(@DestinationVariable long partyId, @Payload String message, Principal principal) {
         Member sender = this.webSocketUserContext.getActor(principal);
 
-        this.chatMessageService.broadcastMessage(partyId, sender, message);
-    }
-
-    @MessageMapping("/chat.send/{partyId}/member/{memberId}")
-    public void handleMessage(@DestinationVariable long partyId, @DestinationVariable long memberId, @Payload String message) {
-        Member sender = this.webSocketUserContext.findById(memberId);
-
-        this.chatMessageService.broadcastMessage(partyId, sender, message);
+        this.chatMessageService.broadcastMessage(sender, partyId, message);
     }
 }

--- a/src/main/java/com/ll/playon/domain/chat/dto/ChatMemberDto.java
+++ b/src/main/java/com/ll/playon/domain/chat/dto/ChatMemberDto.java
@@ -2,6 +2,7 @@ package com.ll.playon.domain.chat.dto;
 
 import com.ll.playon.domain.chat.entity.ChatMember;
 import jakarta.validation.constraints.NotBlank;
+import java.util.Objects;
 import lombok.NonNull;
 
 public record ChatMemberDto(
@@ -17,7 +18,7 @@ public record ChatMemberDto(
         this(
                 chatMember.getPartyMember().getMember().getId(),
                 chatMember.getPartyMember().getMember().getNickname(),
-                chatMember.getPartyMember().getMember().getProfileImg()
+                Objects.requireNonNullElse(chatMember.getPartyMember().getMember().getProfileImg(), "")
         );
     }
 }

--- a/src/main/java/com/ll/playon/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/ll/playon/domain/chat/dto/ChatMessageDto.java
@@ -3,6 +3,7 @@ package com.ll.playon.domain.chat.dto;
 import com.ll.playon.domain.member.entity.Member;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.NonNull;
 
 public record ChatMessageDto(
@@ -27,7 +28,7 @@ public record ChatMessageDto(
                 member.getId(),
                 title,
                 member.getNickname(),
-                member.getProfileImg(),
+                Objects.requireNonNullElse(member.getProfileImg(), ""),
                 message,
                 LocalDateTime.now()
         );
@@ -38,7 +39,7 @@ public record ChatMessageDto(
                 member.getId(),
                 title,
                 member.getNickname(),
-                member.getProfileImg(),
+                Objects.requireNonNullElse(member.getProfileImg(), ""),
                 "[ " + member.getNickname() + " ] 님이 입장하셨습니다.",
                 LocalDateTime.now()
         );
@@ -49,7 +50,7 @@ public record ChatMessageDto(
                 member.getId(),
                 title,
                 member.getNickname(),
-                member.getProfileImg(),
+                Objects.requireNonNullElse(member.getProfileImg(), ""),
                 "[ " + member.getNickname() + " ]님이 퇴장하셨습니다.",
                 LocalDateTime.now()
         );

--- a/src/main/java/com/ll/playon/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/ll/playon/domain/chat/service/ChatMessageService.java
@@ -4,6 +4,7 @@ import com.ll.playon.domain.chat.dto.ChatMemberDto;
 import com.ll.playon.domain.chat.dto.ChatMessageDto;
 import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.title.service.MemberTitleService;
+import com.ll.playon.global.annotation.ChatMemberOnly;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
@@ -15,7 +16,8 @@ public class ChatMessageService {
     private final SimpMessageSendingOperations messagingTemplate;
     private final MemberTitleService memberTitleService;
 
-    public void broadcastMessage(long partyId, Member sender, String message) {
+    @ChatMemberOnly
+    public void broadcastMessage(Member sender, long partyId, String message) {
         String title = this.memberTitleService.getRepresentativeTitle(sender);
         ChatMessageDto messageDto = ChatMessageDto.of(sender, title, message);
 

--- a/src/main/java/com/ll/playon/domain/party/party/type/PartyRole.java
+++ b/src/main/java/com/ll/playon/domain/party/party/type/PartyRole.java
@@ -12,4 +12,12 @@ public enum PartyRole {
     INVITER("초대자");
 
     private final String value;
+
+    public boolean isActive() {
+        return this == OWNER || this == MEMBER;
+    }
+
+    public boolean isWaiting() {
+        return this == PENDING || this == INVITER;
+    }
 }

--- a/src/main/java/com/ll/playon/global/annotation/ChatMemberOnly.java
+++ b/src/main/java/com/ll/playon/global/annotation/ChatMemberOnly.java
@@ -1,0 +1,11 @@
+package com.ll.playon.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ChatMemberOnly {
+}

--- a/src/main/java/com/ll/playon/global/aspect/PartyInviterCheckAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/PartyInviterCheckAspect.java
@@ -32,7 +32,7 @@ public class PartyInviterCheckAspect {
                 .orElseThrow(ErrorCode.PARTY_NOT_FOUND::throwServiceException);
 
         if (isNotPartyInviter(actor, party)) {
-            throw ErrorCode.IS_NOT_PARTY_MEMBER_INVITER.throwServiceException();
+            ErrorCode.IS_NOT_PARTY_MEMBER_INVITER.throwServiceException();
         }
 
         PartyMember partyMember = this.partyMemberRepository.findByMemberAndParty(actor, party)

--- a/src/main/java/com/ll/playon/global/aspect/PartyOwnerCheckAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/PartyOwnerCheckAspect.java
@@ -28,7 +28,7 @@ public class PartyOwnerCheckAspect {
                 .orElseThrow(ErrorCode.PARTY_NOT_FOUND::throwServiceException);
 
         if (isNotPartyOwner(actor, party)) {
-            throw ErrorCode.IS_NOT_PARTY_MEMBER_OWNER.throwServiceException();
+            ErrorCode.IS_NOT_PARTY_MEMBER_OWNER.throwServiceException();
         }
 
         PartyContext.setParty(party);

--- a/src/main/java/com/ll/playon/global/aspect/PartyPendingCheckAspect.java
+++ b/src/main/java/com/ll/playon/global/aspect/PartyPendingCheckAspect.java
@@ -32,7 +32,7 @@ public class PartyPendingCheckAspect {
                 .orElseThrow(ErrorCode.PARTY_NOT_FOUND::throwServiceException);
 
         if (isNotPartyPending(actor, party)) {
-            throw ErrorCode.IS_NOT_PARTY_MEMBER_PENDING.throwServiceException();
+            ErrorCode.IS_NOT_PARTY_MEMBER_PENDING.throwServiceException();
         }
 
         PartyMember partyMember = this.partyMemberRepository.findByMemberAndParty(actor, party)

--- a/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
@@ -104,6 +104,7 @@ public enum ErrorCode {
 
     // ChatMember
     IS_ALREADY_CHAT_MEMBER(HttpStatus.FORBIDDEN, "이미 해당 채팅방에 참여중입니다"),
+    IS_NOT_CHAT_MEMBER(HttpStatus.FORBIDDEN, "채팅방에 입장한 멤버가 아닙니다."),
     CHAT_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅 멤버가 존재하지 않습니다."),
 
     // PartyLog

--- a/src/main/java/com/ll/playon/global/webSocket/config/WebSocketConfig.java
+++ b/src/main/java/com/ll/playon/global/webSocket/config/WebSocketConfig.java
@@ -20,19 +20,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws") // 프론트의 WebSocket 연결 주소
-//                .setAllowedOrigins("*")
                 .setAllowedOriginPatterns("*")
                 .addInterceptors(jwtHandshakeInterceptor)
                 .setHandshakeHandler(customHandshakeHandler)
                 .addInterceptors(jwtHandshakeInterceptor)
                 .withSockJS()   // SockJs Fallback
         ;
-
-        registry.addEndpoint("/ws") // 프론트의 WebSocket 연결 주소
-//                .setAllowedOrigins("*")
-                .setAllowedOriginPatterns("*")
-                .setHandshakeHandler(customHandshakeHandler)
-                .addInterceptors(jwtHandshakeInterceptor);
     }
 
     @Override


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [ ] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 채팅방 정책 추가 적용
- 이미 채팅방 입장 시 별다른 조치 없이 바로 입장 처리

### 2. 채팅방 인가 AOP 적용
- 채팅 멤버용 어노테이션 추가
- 채팅 멤버 인가 `AOP` 적용
- `PartyRoomContext` 및 `ChatMemberContext` 추가
- 메시지는 `ChatMember` 만 전송할 수 있도록 설정
- 퇴장은 `ChatMember` 만 가능하도록 변경

### 3. ChatMessageController 정리
- 사용하지 않는 엔드포인트 메서드 정리

### 4. 파티 멤버 역할 리팩토링
- 기존 `Owner` 와 `Member` 인지를 묶어서 확인할 수 있는 메서드 추가
- 추후 사용할 수도 있으니, 반대를 묶어서 확인할 수 있는 메서드도 추가

### 5. 채팅 이미지 NPE 해결
- 채팅 멤버의 이미지 호출 시 `NPE` 가 발생하지 않도록 수정

### 6. 기존 코드 일부 리팩토링
- 기존 코드 일부 리팩토링 진행