### PR TITLE
[FEAT] 6개월 지난 파티 일괄 삭제

### DIFF
--- a/src/main/java/com/ll/playon/domain/chat/listener/PartyRoomEventListener.java
+++ b/src/main/java/com/ll/playon/domain/chat/listener/PartyRoomEventListener.java
@@ -51,6 +51,6 @@ public class PartyRoomEventListener {
             throw new EventListenerException(ErrorCode.PARTY_ROOM_DELETE_FAILED);
         }
 
-        log.info("삭제된 파티룸: {}개, 삭제 실패: {}개, 실패 파티룸ID: {}", successCount, failedIds.size(), failedIds);
+        log.info("삭제된 파티룸: {}개, 삭제 실패: {}개, 실패 파티룸 ID: {}", successCount, failedIds.size(), failedIds);
     }
 }

--- a/src/main/java/com/ll/playon/domain/chat/policy/PartyRoomPolicy.java
+++ b/src/main/java/com/ll/playon/domain/chat/policy/PartyRoomPolicy.java
@@ -2,11 +2,7 @@ package com.ll.playon.domain.chat.policy;
 
 import com.ll.playon.domain.party.party.entity.Party;
 import java.time.LocalDateTime;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
-@Service
-@RequiredArgsConstructor
 public class PartyRoomPolicy {
     public static boolean shouldDeletePartyRoom(long count, Party party) {
         return count == 0 && party.getPartyAt().plusMinutes(5).isBefore(LocalDateTime.now());

--- a/src/main/java/com/ll/playon/domain/chat/repository/ChatMemberRepository.java
+++ b/src/main/java/com/ll/playon/domain/chat/repository/ChatMemberRepository.java
@@ -26,4 +26,6 @@ public interface ChatMemberRepository extends JpaRepository<ChatMember, Long> {
             GROUP BY cm.partyRoom.id
             """)
     List<ChatMemberCountDto> countByPartyRoomIds(@Param("candidateIds") List<Long> candidateIds);
+
+    void deleteAllByPartyRoom(PartyRoom partyRoom);
 }

--- a/src/main/java/com/ll/playon/domain/chat/scheduler/PartyRoomsScheduler.java
+++ b/src/main/java/com/ll/playon/domain/chat/scheduler/PartyRoomsScheduler.java
@@ -1,4 +1,4 @@
-package com.ll.playon.domain.chat.scheduled;
+package com.ll.playon.domain.chat.scheduler;
 
 import com.ll.playon.domain.chat.event.ChatRoomDetectedAfterGameStartedEvent;
 import com.ll.playon.domain.chat.repository.PartyRoomRepository;
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class DeletePartyRoomsScheduler {
+public class PartyRoomsScheduler {
     private final PartyRoomRepository partyRoomRepository;
     private final ApplicationEventPublisher eventPublisher;
 

--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -320,7 +320,7 @@ public class MemberService {
     public void cancelPendingParty(Member actor, long partyId) {
         PartyMember me = PartyMemberContext.getPartyMember();
 
-        me.delete();
+        me.deleteWithUpdateTotal();
     }
 
     // 파티 초대 승인
@@ -345,7 +345,7 @@ public class MemberService {
     public void rejectPartyInvitation(Member actor, long partyId) {
         PartyMember me = PartyMemberContext.getPartyMember();
 
-        me.delete();
+        me.deleteWithUpdateTotal();
     }
 
     // 내 참여중인 파티 조회

--- a/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
@@ -123,7 +123,7 @@ public class Party {
         }
     }
 
-    public void deletePartyMember(PartyMember partyMember) {
+    public void deletePartyMemberWithUpdateTotal(PartyMember partyMember) {
         if (partyMember.getPartyRole().equals(PartyRole.OWNER) || partyMember.getPartyRole().equals(PartyRole.MEMBER)) {
             this.updateTotal(false);
         }
@@ -156,5 +156,21 @@ public class Party {
 
     public void updateEndTime() {
         this.endedAt = LocalDateTime.now();
+    }
+
+    public Party deleteCascadeAll() {
+        List<PartyMember> partyMembersToDelete = new ArrayList<>(this.partyMembers);
+        for (PartyMember member : partyMembersToDelete) {
+            member.delete();
+        }
+        this.partyMembers.clear();
+
+        List<PartyTag> partyTagsToDelete = new ArrayList<>(this.partyTags);
+        for (PartyTag tag : partyTagsToDelete) {
+            tag.delete();
+        }
+        this.partyTags.clear();
+
+        return this;
     }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/entity/PartyMember.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/PartyMember.java
@@ -65,9 +65,16 @@ public class PartyMember extends BaseTime {
         return this.party != null && this.member.equals(member);
     }
 
+    public void deleteWithUpdateTotal() {
+        if (this.party != null) {
+            this.party.deletePartyMemberWithUpdateTotal(this);
+        }
+    }
+
     public void delete() {
         if (this.party != null) {
-            this.party.deletePartyMember(this);
+            this.party.getPartyMembers().remove(this);
+            this.party = null;
         }
     }
 

--- a/src/main/java/com/ll/playon/domain/party/party/entity/PartyTag.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/PartyTag.java
@@ -61,4 +61,10 @@ public class PartyTag extends BaseTime {
         return Objects.hash(party, type, value);
     }
 
+    public void delete() {
+        if (this.party != null) {
+            this.party.getPartyTags().remove(this);
+            this.party = null;
+        }
+    }
 }

--- a/src/main/java/com/ll/playon/domain/party/party/event/ExpiredPartyDetectedEvent.java
+++ b/src/main/java/com/ll/playon/domain/party/party/event/ExpiredPartyDetectedEvent.java
@@ -1,0 +1,9 @@
+package com.ll.playon.domain.party.party.event;
+
+import com.ll.playon.domain.party.party.entity.Party;
+import java.util.List;
+
+public record ExpiredPartyDetectedEvent(
+        List<Party> candidateIds
+) {
+}

--- a/src/main/java/com/ll/playon/domain/party/party/event/ExpiredPartyDetectedEvent.java
+++ b/src/main/java/com/ll/playon/domain/party/party/event/ExpiredPartyDetectedEvent.java
@@ -4,6 +4,6 @@ import com.ll.playon.domain.party.party.entity.Party;
 import java.util.List;
 
 public record ExpiredPartyDetectedEvent(
-        List<Party> candidateIds
+        List<Party> candidateParties
 ) {
 }

--- a/src/main/java/com/ll/playon/domain/party/party/listener/PartyEventListener.java
+++ b/src/main/java/com/ll/playon/domain/party/party/listener/PartyEventListener.java
@@ -28,7 +28,7 @@ public class PartyEventListener {
         int successCount = 0;
         List<Long> failedIds = new ArrayList<>();
 
-        List<Party> expiredParties = event.candidateIds();
+        List<Party> expiredParties = event.candidateParties();
 
         for (Party party : expiredParties) {
             try {

--- a/src/main/java/com/ll/playon/domain/party/party/listener/PartyEventListener.java
+++ b/src/main/java/com/ll/playon/domain/party/party/listener/PartyEventListener.java
@@ -1,0 +1,56 @@
+package com.ll.playon.domain.party.party.listener;
+
+import com.ll.playon.domain.chat.entity.PartyRoom;
+import com.ll.playon.domain.chat.repository.ChatMemberRepository;
+import com.ll.playon.domain.chat.repository.PartyRoomRepository;
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.party.event.ExpiredPartyDetectedEvent;
+import com.ll.playon.domain.party.party.repository.PartyRepository;
+import com.ll.playon.global.exceptions.ErrorCode;
+import com.ll.playon.global.exceptions.EventListenerException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class PartyEventListener {
+    private final PartyRepository partyRepository;
+    private final PartyRoomRepository partyRoomRepository;
+    private final ChatMemberRepository chatMemberRepository;
+
+    @EventListener
+    public void handle(ExpiredPartyDetectedEvent event) {
+        int successCount = 0;
+        List<Long> failedIds = new ArrayList<>();
+
+        List<Party> expiredParties = event.candidateIds();
+
+        for (Party party : expiredParties) {
+            try {
+                PartyRoom partyRoom = this.partyRoomRepository.findByParty(party).orElse(null);
+
+                if (partyRoom != null) {
+                    this.chatMemberRepository.deleteAllByPartyRoom(partyRoom);
+                    this.partyRoomRepository.delete(partyRoom);
+                }
+
+                this.partyRepository.delete(party.deleteCascadeAll());
+                successCount++;
+            } catch (Exception ex) {
+                failedIds.add(party.getId());
+                log.error("id={}번 파티 삭제 실패", party.getId(), ex);
+            }
+        }
+
+        if (successCount == 0) {
+            throw new EventListenerException(ErrorCode.PARTY_DELETE_FAILED);
+        }
+
+        log.info("삭제된 파티: {}개, 삭제 실패: {}개, 실패 파티 ID: {}", successCount, failedIds.size(), failedIds);
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyMemberRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyMemberRepository.java
@@ -30,7 +30,7 @@ public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> 
                   AND pm.member.id <> :myId
                   AND pm.partyRole IN ('OWNER','MEMBER')
             """)
-    List<Long> findMemberIdsInPartiesExceptMe(@Param("candidateIds") List<Long> partyIds, @Param("myId") Long myId);
+    List<Long> findMemberIdsInPartiesExceptMe(@Param("candidateParties") List<Long> partyIds, @Param("myId") Long myId);
 
     // 그 멤버들이 참여한 파티 중에서 내가 참여한 파티 제외
     @Query("""

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyMemberRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyMemberRepository.java
@@ -30,7 +30,7 @@ public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> 
                   AND pm.member.id <> :myId
                   AND pm.partyRole IN ('OWNER','MEMBER')
             """)
-    List<Long> findMemberIdsInPartiesExceptMe(@Param("candidateParties") List<Long> partyIds, @Param("myId") Long myId);
+    List<Long> findMemberIdsInPartiesExceptMe(@Param("partyIds") List<Long> partyIds, @Param("myId") Long myId);
 
     // 그 멤버들이 참여한 파티 중에서 내가 참여한 파티 제외
     @Query("""

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyMemberRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyMemberRepository.java
@@ -30,7 +30,7 @@ public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> 
                   AND pm.member.id <> :myId
                   AND pm.partyRole IN ('OWNER','MEMBER')
             """)
-    List<Long> findMemberIdsInPartiesExceptMe(@Param("partyIds") List<Long> partyIds, @Param("myId") Long myId);
+    List<Long> findMemberIdsInPartiesExceptMe(@Param("candidateIds") List<Long> partyIds, @Param("myId") Long myId);
 
     // 그 멤버들이 참여한 파티 중에서 내가 참여한 파티 제외
     @Query("""

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -75,7 +75,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             FROM Party p
             WHERE p.id IN :partyIds
             """)
-    List<Party> findPartiesByIds(@Param("candidateIds") List<Long> partyIds);
+    List<Party> findPartiesByIds(@Param("partyIds") List<Long> partyIds);
 
     @Query("""
             SELECT pt
@@ -83,7 +83,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             JOIN FETCH pt.party p
             WHERE p.id IN :partyIds
             """)
-    List<PartyTag> findPartyTagsByPartyIds(@Param("candidateIds") List<Long> partyIds);
+    List<PartyTag> findPartyTagsByPartyIds(@Param("partyIds") List<Long> partyIds);
 
     @Query("""
             SELECT pm
@@ -92,7 +92,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             WHERE p.id IN :partyIds
             AND (pm.partyRole = 'MEMBER' OR pm.partyRole = 'OWNER')
             """)
-    List<PartyMember> findPartyMembersByPartyIds(@Param("candidateIds") List<Long> partyIds);
+    List<PartyMember> findPartyMembersByPartyIds(@Param("partyIds") List<Long> partyIds);
 
     Page<Party> findByGame(SteamGame game, Pageable pageable);
 
@@ -114,7 +114,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             AND p.id IN :partyIds
             ORDER BY p.createdAt DESC
             """)
-    List<Party> findPublicCompletedPartiesIn(@Param("candidateIds") List<Long> partyIds, Pageable pageable);
+    List<Party> findPublicCompletedPartiesIn(@Param("partyIds") List<Long> partyIds, Pageable pageable);
 
     @Query("""
                 SELECT p.game.appid AS appid, COUNT(p) AS playCount

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -75,7 +75,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             FROM Party p
             WHERE p.id IN :partyIds
             """)
-    List<Party> findPartiesByIds(@Param("partyIds") List<Long> partyIds);
+    List<Party> findPartiesByIds(@Param("candidateIds") List<Long> partyIds);
 
     @Query("""
             SELECT pt
@@ -83,7 +83,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             JOIN FETCH pt.party p
             WHERE p.id IN :partyIds
             """)
-    List<PartyTag> findPartyTagsByPartyIds(@Param("partyIds") List<Long> partyIds);
+    List<PartyTag> findPartyTagsByPartyIds(@Param("candidateIds") List<Long> partyIds);
 
     @Query("""
             SELECT pm
@@ -92,7 +92,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             WHERE p.id IN :partyIds
             AND (pm.partyRole = 'MEMBER' OR pm.partyRole = 'OWNER')
             """)
-    List<PartyMember> findPartyMembersByPartyIds(@Param("partyIds") List<Long> partyIds);
+    List<PartyMember> findPartyMembersByPartyIds(@Param("candidateIds") List<Long> partyIds);
 
     Page<Party> findByGame(SteamGame game, Pageable pageable);
 
@@ -114,7 +114,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             AND p.id IN :partyIds
             ORDER BY p.createdAt DESC
             """)
-    List<Party> findPublicCompletedPartiesIn(@Param("partyIds") List<Long> partyIds, Pageable pageable);
+    List<Party> findPublicCompletedPartiesIn(@Param("candidateIds") List<Long> partyIds, Pageable pageable);
 
     @Query("""
                 SELECT p.game.appid AS appid, COUNT(p) AS playCount
@@ -185,4 +185,11 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             ORDER BY p.endedAt DESC
             """)
     List<Party> findRecentCompletedPartiesWithLogs(@Param("partyStatus") PartyStatus partyStatus, Pageable pageable);
+
+    @Query("""
+            SELECT p
+            FROM Party p
+            WHERE p.partyAt < :deadLine
+            """)
+    List<Party> findExpiredPartiesToDelete(@Param("deadLine") LocalDateTime deadLine);
 }

--- a/src/main/java/com/ll/playon/domain/party/party/scheduler/PartyScheduler.java
+++ b/src/main/java/com/ll/playon/domain/party/party/scheduler/PartyScheduler.java
@@ -1,0 +1,30 @@
+package com.ll.playon.domain.party.party.scheduler;
+
+import com.ll.playon.domain.party.party.entity.Party;
+import com.ll.playon.domain.party.party.event.ExpiredPartyDetectedEvent;
+import com.ll.playon.domain.party.party.repository.PartyRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class PartyScheduler {
+    private final PartyRepository partyRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Scheduled(cron = "0 0 4 * * ?")
+    @Transactional
+    public void deleteExpiredParties() {
+        LocalDateTime deadLine = LocalDateTime.now().minusMonths(6);
+        List<Party> expiredParties = this.partyRepository.findExpiredPartiesToDelete(deadLine);
+
+        if (!expiredParties.isEmpty()) {
+            this.eventPublisher.publishEvent(new ExpiredPartyDetectedEvent(expiredParties));
+        }
+    }
+}

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -395,7 +395,7 @@ public class PartyService {
 
         PartyMember pendingMember = this.getPendingMember(memberId, party);
 
-        pendingMember.delete();
+        pendingMember.deleteWithUpdateTotal();
     }
 
     // TODO: 알림 기능 구현 후 수정 예정

--- a/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/ll/playon/global/exceptions/ErrorCode.java
@@ -60,7 +60,7 @@ public enum ErrorCode {
     GUILD_ID_MISMATCH(HttpStatus.BAD_REQUEST, "요청한 길드와 일치하지 않습니다."),
     GUILD_REQUEST_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 길드 요청입니다."),
     GUILD_APPROVAL_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "승인 권한이 없습니다."),
-    GUILD_MEMBER_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST,"길드 최대 인원을 초과했습니다."),
+    GUILD_MEMBER_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "길드 최대 인원을 초과했습니다."),
 
 
     // GuildMember
@@ -84,6 +84,7 @@ public enum ErrorCode {
     IS_ALREADY_INVITING_PARTY(HttpStatus.FORBIDDEN, "파티 초대가 진행 중입니다."),
     PARTY_IS_FULL(HttpStatus.FORBIDDEN, "파티 정원이 가득 찼습니다."),
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "파티가 존재하지 않습니다."),
+    PARTY_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파티 삭제에 문제가 생겨 모든 파티 삭제가 불가능합니다."),
 
     // PartyMember
     IS_NOT_PARTY_MEMBER_OWNER(HttpStatus.FORBIDDEN, "해당 파티의 파티장이 아닙니다."),


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 파티 삭제 메서드 추가
- 파티를 삭제(Hard Delete)하기 위한 메서드 추가
  - 관련된 모든 연관관계를 끊어주는 메서드 추가

### 2. 파티 삭제용 이벤트 생성
- 파티 삭제용 이벤트 생성

### 3. 파티 삭제 판별 스케쥴러 생성
- 매 새벽 4시마다 `partyAt` 이 6개월이 지난 파티들을 선별하는 스케쥴러 생성
- 해당하는 파티들이 존재하면, 이벤트에 추가하여 리스너에서 처리하도록 구현

### 4. 파티 삭제 리스너 구현
- 스케쥴러에서 판별된 파티 삭제 진행
- 모든 연관관계를 먼저 끊은 후, 파티 삭제 진행
<br>

> ### 파티 삭제 스케쥴러에서 EventListener 선택 이유
- 삭제 대상을 판별하는 스케쥴러와, 실제 삭제를 진행하는 이벤트리스너를 나누어서 __책임 분리 및 관심사 분리, 코드 가독성 및 유지보수성 높임__. __단일 책임 원칙(SRP)__ 준수
- 이벤트리스너는 __트랜잭션의 바깥에서 작동__하므로, __하나의 파티 삭제에 실패해도 나머지에는 영향을 주지 않음__
- 지금 프로세스 대로면 별도의 로깅으로 실패 파티 ID를 얻을 수 있으므로, __후처리도 간편하며 모니터링하기도 좋음__
- __일괄 실패__ 시 EventListenerException을 발생시켜, __모든 처리가 진행되지 않은 이벤트 리스너 쪽의 문제임을 확실히 알 수 있음__
- 이후 이를 어떻게 처리할지, __후처리에 대한 확장성도 열려있음 (Kafka, 실패용 DB 추가, 알림 전송 등)__