### PR TITLE
[REFACTOR] 로그백 설정 수정

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,11 +2,11 @@
 <configuration>
     <!-- 로그 파일 기본 경로 및 이름 -->
     <property name="LOG_DIR" value="./logs/"/>
-    <property name="PARTY_DELETE_LOG_DIR" value="./logs/event/party/delete"/>
+    <property name="PARTY_DELETE_LOG_DIR" value="./logs/event/party/delete/"/>
     <property name="LOG_FILE_NAME" value="info/info"/>
     <property name="ERROR_LOG_FILE_NAME" value="error/error"/>
-    <property name="PARTY_DELETE_INFO_LOG_FILE" value="${PARTY_DELETE_LOG_DIR}/info"/>
-    <property name="PARTY_DELETE_ERROR_LOG_FILE" value="${PARTY_DELETE_LOG_DIR}/error"/>
+    <property name="PARTY_DELETE_INFO_LOG_FILE" value="${PARTY_DELETE_LOG_DIR}/info/info"/>
+    <property name="PARTY_DELETE_ERROR_LOG_FILE" value="${PARTY_DELETE_LOG_DIR}/error/error"/>
 
     <!-- 콘솔 출력 Appender -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -99,8 +99,15 @@
         <appender-ref ref="CONSOLE"/>
     </logger>
 
-    <!-- 파티 삭제 이벤트 관련 로거 -->
+    <!-- 파티룸 삭제 이벤트 관련 로거 -->
     <logger name="com.ll.playon.domain.chat.listener.PartyRoomEventListener" level="INFO" additivity="false">
+        <appender-ref ref="PARTY_DELETE_INFO_FILE"/>
+        <appender-ref ref="PARTY_DELETE_ERROR_FILE"/>
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <!-- 파티 삭제 이벤트 관련 로거 -->
+    <logger name="com.ll.playon.domain.party.party.listener.PartyEventListener" level="INFO" additivity="false">
         <appender-ref ref="PARTY_DELETE_INFO_FILE"/>
         <appender-ref ref="PARTY_DELETE_ERROR_FILE"/>
         <appender-ref ref="CONSOLE"/>


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 로그백 설정 추가
- 파티 삭제 스케쥴러를 통한 정보가 기존 `party/delete` 폴더 내부에 잘 담기도록 수정

### 2. 로그백 폴더 수정
- 파티 관련 삭제 이벤트가 제대로 `info` 폴더와 `error` 폴더로 나뉠 수 있도록 수정