### PR TITLE
[FIX] 파티룸 스케쥴러 삭제 버그 수정

### DIFF
--- a/src/main/java/com/ll/playon/domain/chat/dto/RemainMemberCountDto.java
+++ b/src/main/java/com/ll/playon/domain/chat/dto/RemainMemberCountDto.java
@@ -1,7 +1,8 @@
 package com.ll.playon.domain.chat.dto;
 
-public record ChatMemberCountDto(
+public record RemainMemberCountDto(
         long partyRoomId,
+
         long remainCount
 ) {
 }

--- a/src/main/java/com/ll/playon/domain/chat/event/PartyRoomExpiredEvent.java
+++ b/src/main/java/com/ll/playon/domain/chat/event/PartyRoomExpiredEvent.java
@@ -1,10 +1,11 @@
 package com.ll.playon.domain.chat.event;
 
+import com.ll.playon.domain.chat.entity.PartyRoom;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
-public record ChatRoomDetectedAfterGameStartedEvent(
+public record PartyRoomExpiredEvent(
         @NotNull
-        List<Long> candidateIds
+        List<PartyRoom> candidatePartyRooms
 ) {
 }

--- a/src/main/java/com/ll/playon/domain/chat/event/PartyRoomUnusedEvent.java
+++ b/src/main/java/com/ll/playon/domain/chat/event/PartyRoomUnusedEvent.java
@@ -1,0 +1,10 @@
+package com.ll.playon.domain.chat.event;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record PartyRoomUnusedEvent(
+        @NotNull
+        List<Long> candidateIds
+) {
+}

--- a/src/main/java/com/ll/playon/domain/chat/listener/PartyRoomEventListener.java
+++ b/src/main/java/com/ll/playon/domain/chat/listener/PartyRoomEventListener.java
@@ -1,16 +1,14 @@
 package com.ll.playon.domain.chat.listener;
 
-import com.ll.playon.domain.chat.dto.ChatMemberCountDto;
-import com.ll.playon.domain.chat.event.ChatRoomDetectedAfterGameStartedEvent;
-import com.ll.playon.domain.chat.policy.PartyRoomPolicy;
-import com.ll.playon.domain.chat.repository.ChatMemberRepository;
+import com.ll.playon.domain.chat.entity.PartyRoom;
+import com.ll.playon.domain.chat.event.PartyRoomExpiredEvent;
+import com.ll.playon.domain.chat.event.PartyRoomUnusedEvent;
 import com.ll.playon.domain.chat.repository.PartyRoomRepository;
+import com.ll.playon.domain.chat.service.ChatService;
 import com.ll.playon.global.exceptions.ErrorCode;
 import com.ll.playon.global.exceptions.EventListenerException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -20,30 +18,47 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @RequiredArgsConstructor
 public class PartyRoomEventListener {
-    private final ChatMemberRepository chatMemberRepository;
+    private final ChatService chatService;
     private final PartyRoomRepository partyRoomRepository;
 
     @EventListener
-    public void handle(ChatRoomDetectedAfterGameStartedEvent event) {
+    public void handleUnused(PartyRoomUnusedEvent event) {
         int successCount = 0;
         List<Long> failedIds = new ArrayList<>();
 
         List<Long> candidateIds = event.candidateIds();
 
-        Map<Long, Long> remainCountMap = this.chatMemberRepository.countByPartyRoomIds(candidateIds).stream()
-                .collect(Collectors.toMap(ChatMemberCountDto::partyRoomId, ChatMemberCountDto::remainCount));
-
         for (Long partyRoomId : candidateIds) {
-            Long remainCount = remainCountMap.getOrDefault(partyRoomId, 0L);
-
             try {
-                if (PartyRoomPolicy.shouldDeletePartyRoom(remainCount)) {
-                    this.partyRoomRepository.deleteById(partyRoomId);
-                    successCount++;
-                }
+                this.partyRoomRepository.deleteById(partyRoomId);
+                successCount++;
             } catch (Exception ex) {
                 failedIds.add(partyRoomId);
                 log.error("id={}번 파티룸 삭제 실패", partyRoomId, ex);
+            }
+        }
+
+        if (successCount == 0) {
+            throw new EventListenerException(ErrorCode.PARTY_ROOM_DELETE_FAILED);
+        }
+
+        log.info("삭제된 파티룸: {}개, 삭제 실패: {}개, 실패 파티룸 ID: {}", successCount, failedIds.size(), failedIds);
+    }
+
+    @EventListener
+    public void handleExpired(PartyRoomExpiredEvent event) {
+        int successCount = 0;
+        List<Long> failedIds = new ArrayList<>();
+
+        List<PartyRoom> expiredPartyRooms = event.candidatePartyRooms();
+
+        for (PartyRoom partyRoom : expiredPartyRooms) {
+            try {
+                this.chatService.deletePartyRoomByHard(partyRoom);
+                successCount++;
+            } catch (Exception ex) {
+                failedIds.add(partyRoom.getId());
+                log.error("id={}번 파티룸 삭제 실패", partyRoom.getId(), ex);
             }
         }
 

--- a/src/main/java/com/ll/playon/domain/chat/repository/ChatMemberRepository.java
+++ b/src/main/java/com/ll/playon/domain/chat/repository/ChatMemberRepository.java
@@ -1,6 +1,6 @@
 package com.ll.playon.domain.chat.repository;
 
-import com.ll.playon.domain.chat.dto.ChatMemberCountDto;
+import com.ll.playon.domain.chat.dto.RemainMemberCountDto;
 import com.ll.playon.domain.chat.entity.ChatMember;
 import com.ll.playon.domain.chat.entity.PartyRoom;
 import com.ll.playon.domain.party.party.entity.PartyMember;
@@ -20,12 +20,12 @@ public interface ChatMemberRepository extends JpaRepository<ChatMember, Long> {
     Long countByPartyRoom(PartyRoom partyRoom);
 
     @Query("""
-            SELECT new com.ll.playon.domain.chat.dto.ChatMemberCountDto(cm.partyRoom.id, COUNT(cm))
+            SELECT new com.ll.playon.domain.chat.dto.RemainMemberCountDto(cm.partyRoom.id, COUNT(cm))
             FROM ChatMember cm
             WHERE cm.partyRoom.id IN :candidateIds
             GROUP BY cm.partyRoom.id
             """)
-    List<ChatMemberCountDto> countByPartyRoomIds(@Param("candidateIds") List<Long> candidateIds);
+    List<RemainMemberCountDto> countByPartyRoomIds(@Param("candidateIds") List<Long> candidateIds);
 
     void deleteAllByPartyRoom(PartyRoom partyRoom);
 }

--- a/src/main/java/com/ll/playon/domain/chat/repository/PartyRoomRepository.java
+++ b/src/main/java/com/ll/playon/domain/chat/repository/PartyRoomRepository.java
@@ -16,7 +16,16 @@ public interface PartyRoomRepository extends JpaRepository<PartyRoom, Long> {
             SELECT pr.id
             from PartyRoom pr
             JOIN pr.party p
-            WHERE p.partyAt <= :deadlineTime
+            WHERE p.partyAt <= :deadline
             """)
-    List<Long> findDeletablePartyRooms(@Param("deadlineTime") LocalDateTime deadlineTime);
+    List<Long> findDeletablePartyRoomIds(@Param("deadline") LocalDateTime deadline);
+
+    @Query("""
+            SELECT pr
+            from PartyRoom pr
+            JOIN pr.party p
+            WHERE p.partyAt <= :deadline
+            AND (p.partyStatus != 'COMPLETED' OR p.endedAt IS NULL)
+            """)
+    List<PartyRoom> findDeletablePartyRooms(@Param("deadline") LocalDateTime deadline);
 }

--- a/src/main/java/com/ll/playon/domain/chat/scheduler/PartyRoomsScheduler.java
+++ b/src/main/java/com/ll/playon/domain/chat/scheduler/PartyRoomsScheduler.java
@@ -1,28 +1,55 @@
 package com.ll.playon.domain.chat.scheduler;
 
-import com.ll.playon.domain.chat.event.ChatRoomDetectedAfterGameStartedEvent;
+import com.ll.playon.domain.chat.dto.RemainMemberCountDto;
+import com.ll.playon.domain.chat.entity.PartyRoom;
+import com.ll.playon.domain.chat.event.PartyRoomUnusedEvent;
+import com.ll.playon.domain.chat.event.PartyRoomExpiredEvent;
+import com.ll.playon.domain.chat.repository.ChatMemberRepository;
 import com.ll.playon.domain.chat.repository.PartyRoomRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 @Component
 @RequiredArgsConstructor
 public class PartyRoomsScheduler {
     private final PartyRoomRepository partyRoomRepository;
+    private final ChatMemberRepository chatMemberRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     @Scheduled(fixedDelay = 1000 * 60 * 10)
-    public void deleteUnusedPartyRooms() {
-        LocalDateTime deadlineTime = LocalDateTime.now().minusMinutes(5);
-        List<Long> candidates = this.partyRoomRepository.findDeletablePartyRooms(deadlineTime);
+    public void detectAndPublishUnusedPartyRooms() {
+        LocalDateTime deadline = LocalDateTime.now().minusMinutes(5);
+        List<Long> startedPartyRoomIds = this.partyRoomRepository.findDeletablePartyRoomIds(deadline);
+
+        if (startedPartyRoomIds.isEmpty()) {
+            return;
+        }
+
+        Map<Long, Long> remainCountMap = this.chatMemberRepository.countByPartyRoomIds(startedPartyRoomIds).stream()
+                .collect(Collectors.toMap(RemainMemberCountDto::partyRoomId, RemainMemberCountDto::remainCount));
+
+        List<Long> candidateIds = startedPartyRoomIds.stream()
+                .filter(partyRoomId -> remainCountMap.getOrDefault(partyRoomId, 0L) == 0)
+                .toList();
+
+        if (!candidateIds.isEmpty()) {
+            this.eventPublisher.publishEvent(new PartyRoomUnusedEvent(candidateIds));
+        }
+    }
+
+    @Scheduled(fixedDelay = 1000 * 60 * 60)
+    public void detectAndPublishExpiredPartyRooms() {
+        LocalDateTime deadline = LocalDateTime.now().minusHours(24);
+        List<PartyRoom> candidates = this.partyRoomRepository.findDeletablePartyRooms(deadline);
 
         if (!candidates.isEmpty()) {
-            this.eventPublisher.publishEvent(new ChatRoomDetectedAfterGameStartedEvent(candidates));
+            this.eventPublisher.publishEvent(new PartyRoomExpiredEvent(candidates));
         }
     }
 }

--- a/src/main/java/com/ll/playon/domain/chat/service/ChatService.java
+++ b/src/main/java/com/ll/playon/domain/chat/service/ChatService.java
@@ -93,8 +93,7 @@ public class ChatService {
         // 파티 진행 시간 5분 이상 지나고, 채팅인원이 0명이면 채팅방 삭제, 브로드캐스트 생략
         if (PartyRoomPolicy.shouldDeletePartyRoom(remainCount, party)) {
             this.partyRoomRepository.delete(partyRoom);
-            party.updatePartyStatus(PartyStatus.COMPLETED);
-            party.updateEndTime();
+            party.closeParty();
             return;
         }
 
@@ -103,6 +102,15 @@ public class ChatService {
         this.chatMessageService.broadcastLeaveMessage(partyId, actor, title);
 
         this.chatMessageService.broadcastMemberList(partyId, this.getChatMemberDtos(partyRoom));
+    }
+
+    // 스케쥴러에서 파티룸 삭제
+    @Transactional
+    public void deletePartyRoomByHard(PartyRoom partyRoom) {
+        partyRoom.getParty().closeParty();
+
+        this.chatMemberRepository.deleteAllByPartyRoom(partyRoom);
+        this.partyRoomRepository.delete(partyRoom);
     }
 
     // Party로 PartyRoom 조회

--- a/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
@@ -37,7 +37,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
                 @Index(name = "idx_party_status_public_total_max_party_at", columnList = "party_status, is_public, total, maximum, party_at"),
                 @Index(name = "idx_party_public_status_ended_created", columnList = "is_public, party_status, ended_at, created_at"),
                 @Index(name = "idx_party_created_game", columnList = "created_at, game_id"),
-                @Index(name = "idx_party_party_at", columnList = "party_at")
+                @Index(name = "idx_party_party_at_status_ended", columnList = "party_at, party_status, ended_at")
         }
 )
 @Getter
@@ -154,7 +154,8 @@ public class Party {
         this.hit += 1;
     }
 
-    public void updateEndTime() {
+    public void closeParty() {
+        this.updatePartyStatus(PartyStatus.COMPLETED);
         this.endedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/ll/playon/domain/party/party/event/ExpiredPartyDetectedEvent.java
+++ b/src/main/java/com/ll/playon/domain/party/party/event/ExpiredPartyDetectedEvent.java
@@ -1,9 +1,11 @@
 package com.ll.playon.domain.party.party.event;
 
 import com.ll.playon.domain.party.party.entity.Party;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record ExpiredPartyDetectedEvent(
+        @NotNull
         List<Party> candidateParties
 ) {
 }

--- a/src/main/java/com/ll/playon/domain/party/party/listener/PartyEventListener.java
+++ b/src/main/java/com/ll/playon/domain/party/party/listener/PartyEventListener.java
@@ -1,11 +1,8 @@
 package com.ll.playon.domain.party.party.listener;
 
-import com.ll.playon.domain.chat.entity.PartyRoom;
-import com.ll.playon.domain.chat.repository.ChatMemberRepository;
-import com.ll.playon.domain.chat.repository.PartyRoomRepository;
 import com.ll.playon.domain.party.party.entity.Party;
 import com.ll.playon.domain.party.party.event.ExpiredPartyDetectedEvent;
-import com.ll.playon.domain.party.party.repository.PartyRepository;
+import com.ll.playon.domain.party.party.service.PartyService;
 import com.ll.playon.global.exceptions.ErrorCode;
 import com.ll.playon.global.exceptions.EventListenerException;
 import java.util.ArrayList;
@@ -19,9 +16,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @RequiredArgsConstructor
 public class PartyEventListener {
-    private final PartyRepository partyRepository;
-    private final PartyRoomRepository partyRoomRepository;
-    private final ChatMemberRepository chatMemberRepository;
+    private final PartyService partyService;
 
     @EventListener
     public void handle(ExpiredPartyDetectedEvent event) {
@@ -32,14 +27,7 @@ public class PartyEventListener {
 
         for (Party party : expiredParties) {
             try {
-                PartyRoom partyRoom = this.partyRoomRepository.findByParty(party).orElse(null);
-
-                if (partyRoom != null) {
-                    this.chatMemberRepository.deleteAllByPartyRoom(partyRoom);
-                    this.partyRoomRepository.delete(partyRoom);
-                }
-
-                this.partyRepository.delete(party.deleteCascadeAll());
+                this.partyService.deletePartyByHard(party);
                 successCount++;
             } catch (Exception ex) {
                 failedIds.add(party.getId());

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -189,7 +189,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
     @Query("""
             SELECT p
             FROM Party p
-            WHERE p.partyAt < :deadLine
+            WHERE p.partyAt < :deadline
             """)
-    List<Party> findExpiredPartiesToDelete(@Param("deadLine") LocalDateTime deadLine);
+    List<Party> findExpiredPartiesToDelete(@Param("deadline") LocalDateTime deadline);
 }

--- a/src/main/java/com/ll/playon/domain/party/party/scheduler/PartyScheduler.java
+++ b/src/main/java/com/ll/playon/domain/party/party/scheduler/PartyScheduler.java
@@ -19,9 +19,9 @@ public class PartyScheduler {
 
     @Scheduled(cron = "0 0 4 * * ?")
     @Transactional
-    public void deleteExpiredParties() {
-        LocalDateTime deadLine = LocalDateTime.now().minusMonths(6);
-        List<Party> expiredParties = this.partyRepository.findExpiredPartiesToDelete(deadLine);
+    public void detectAndPublishExpiredParties() {
+        LocalDateTime deadline = LocalDateTime.now().minusMonths(6);
+        List<Party> expiredParties = this.partyRepository.findExpiredPartiesToDelete(deadline);
 
         if (!expiredParties.isEmpty()) {
             this.eventPublisher.publishEvent(new ExpiredPartyDetectedEvent(expiredParties));

--- a/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
+++ b/src/main/java/com/ll/playon/domain/party/party/service/PartyService.java
@@ -2,6 +2,7 @@ package com.ll.playon.domain.party.party.service;
 
 import com.ll.playon.domain.chat.entity.PartyRoom;
 import com.ll.playon.domain.chat.mapper.PartyRoomMapper;
+import com.ll.playon.domain.chat.repository.ChatMemberRepository;
 import com.ll.playon.domain.chat.repository.PartyRoomRepository;
 import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.game.game.repository.GameRepository;
@@ -72,6 +73,7 @@ public class PartyService {
     private final MemberTitleService memberTitleService;
     private final PartyRepository partyRepository;
     private final PartyRoomRepository partyRoomRepository;
+    private final ChatMemberRepository chatMemberRepository;
     private final GameRepository gameRepository;
     private final TitleEvaluator titleEvaluator;
 
@@ -431,6 +433,18 @@ public class PartyService {
         party.addPartyMember(PartyMemberMapper.of(invitedActor, PartyRole.INVITER));
 
         // TODO: 알람?
+    }
+
+    // 스케쥴러에서 파티 삭제
+    @Transactional
+    public void deletePartyByHard(Party party) {
+        PartyRoom partyRoom = this.partyRoomRepository.findByParty(party)
+                .orElseThrow(ErrorCode.PARTY_ROOM_NOT_FOUND::throwServiceException);
+
+        this.chatMemberRepository.deleteAllByPartyRoom(partyRoom);
+        this.partyRoomRepository.delete(partyRoom);
+
+        this.partyRepository.delete(party.deleteCascadeAll());
     }
 
     // 파티 ID로 파티 조회


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 스케쥴링에서 이벤트로 넘겨줄 때의 판단 변경
- 기존 `Listner` 에서 해결하던 방식은 파티가 시작되기만 하면 에러가 발생
  - 이는 `ChatMember` 가 0보다 크기 때문에, 존재하는 모든 파티룸이 활성화된 상태면 이를 삭제할 수 없어서 설정해둔 `EventListenerException` 을 터트림
- 삭제 처리 이벤트에 등록할 판단 방식을 스케쥴러 내부에서 모두 하도록 변경

### 2. 파티룸 삭제 스케쥴링 추가
- `partyAt` 보다 __24시간__이 지난 파티룸을 삭제 판단하는 스케쥴링 추가
- 이에 따른 `Event` 및 `Listener` , 레코드 추가
- 파티룸 삭제 전, 파티의 상태를 `COMPLETED` 로 변경 및 `endedAt` 을 현재 시간으로 변경하도록 구현

### 3. 인덱스 변경
- 쿼리의 조건이 추가됨에 따라, 이를 잘 활용할 수 있도록 기존의 `Party` 엔티티의 인덱스 필드 일부 변경

### 4. 기존 코드 리팩토링
- 어울리지 않는 메서드명 및 검증, 중복 제거 등 리팩토링