### PR TITLE
[FIX] 파티 결과 응답에 게임 헤더 이미지 추가

### DIFF
--- a/src/main/java/com/ll/playon/domain/game/game/dto/response/GameDetailWithPartyResponse.java
+++ b/src/main/java/com/ll/playon/domain/game/game/dto/response/GameDetailWithPartyResponse.java
@@ -1,7 +1,6 @@
 package com.ll.playon.domain.game.game.dto.response;
 
 import com.ll.playon.domain.game.game.entity.SteamGame;
-import com.ll.playon.domain.image.repository.ImageRepository;
 import com.ll.playon.domain.party.party.dto.PartyDetailMemberDto;
 import com.ll.playon.domain.party.party.dto.PartyDetailTagDto;
 import com.ll.playon.domain.party.party.dto.response.GetCompletedPartyDto;

--- a/src/main/java/com/ll/playon/domain/party/party/dto/response/GetCompletedPartyDto.java
+++ b/src/main/java/com/ll/playon/domain/party/party/dto/response/GetCompletedPartyDto.java
@@ -20,6 +20,8 @@ public record GetCompletedPartyDto(
         @NotBlank
         String gameName,
 
+        String gameHeaderImg,
+
         @NonNull
         String mvpName,
 
@@ -46,6 +48,7 @@ public record GetCompletedPartyDto(
                 party.getId(),
                 party.getName(),
                 party.getGame().getName(),
+                party.getGame().getHeaderImage(),
                 mvp.getMember().getNickname(),
                 mvp.getMvpPoint(),
                 Objects.requireNonNullElse(mvp.getMember().getProfileImg(), ""),


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 파티 결과 응답값 추가
- 파티 결과 응답값에서 게임의 헤더 이미지를 주지 않던 것 수정