### PR TITLE
[FIX] 로그 파일 잘못된 형식 저장 해결 및 Lazy Loading으로 인한 문제 해결

### DIFF
--- a/src/main/java/com/ll/playon/domain/chat/listener/PartyRoomEventListener.java
+++ b/src/main/java/com/ll/playon/domain/chat/listener/PartyRoomEventListener.java
@@ -34,7 +34,7 @@ public class PartyRoomEventListener {
                 successCount++;
             } catch (Exception ex) {
                 failedIds.add(partyRoomId);
-                log.error("id={}번 파티룸 삭제 실패", partyRoomId, ex);
+                log.error("id={}번 파티룸 삭제 실패", partyRoomId);
             }
         }
 
@@ -58,7 +58,7 @@ public class PartyRoomEventListener {
                 successCount++;
             } catch (Exception ex) {
                 failedIds.add(partyRoom.getId());
-                log.error("id={}번 파티룸 삭제 실패", partyRoom.getId(), ex);
+                log.error("id={}번 파티룸 삭제 실패", partyRoom.getId());
             }
         }
 

--- a/src/main/java/com/ll/playon/domain/chat/service/ChatService.java
+++ b/src/main/java/com/ll/playon/domain/chat/service/ChatService.java
@@ -16,6 +16,7 @@ import com.ll.playon.domain.party.party.context.PartyContext;
 import com.ll.playon.domain.party.party.context.PartyMemberContext;
 import com.ll.playon.domain.party.party.entity.Party;
 import com.ll.playon.domain.party.party.entity.PartyMember;
+import com.ll.playon.domain.party.party.repository.PartyRepository;
 import com.ll.playon.domain.party.party.type.PartyStatus;
 import com.ll.playon.domain.title.service.MemberTitleService;
 import com.ll.playon.global.annotation.ActivePartyMemberOnly;
@@ -33,6 +34,7 @@ public class ChatService {
     private final ChatMessageService chatMessageService;
     private final MemberTitleService memberTitleService;
     private final ChatMemberRepository chatMemberRepository;
+    private final PartyRepository partyRepository;
     private final PartyRoomRepository partyRoomRepository;
 
     // 채팅방 입장
@@ -107,7 +109,10 @@ public class ChatService {
     // 스케쥴러에서 파티룸 삭제
     @Transactional
     public void deletePartyRoomByHard(PartyRoom partyRoom) {
-        partyRoom.getParty().closeParty();
+        Party party = this.partyRepository.findByPartyRoom(partyRoom)
+                .orElseThrow(ErrorCode.PARTY_NOT_FOUND::throwServiceException);
+
+        party.closeParty();
 
         this.chatMemberRepository.deleteAllByPartyRoom(partyRoom);
         this.partyRoomRepository.delete(partyRoom);

--- a/src/main/java/com/ll/playon/domain/party/party/listener/PartyEventListener.java
+++ b/src/main/java/com/ll/playon/domain/party/party/listener/PartyEventListener.java
@@ -31,7 +31,7 @@ public class PartyEventListener {
                 successCount++;
             } catch (Exception ex) {
                 failedIds.add(party.getId());
-                log.error("id={}번 파티 삭제 실패", party.getId(), ex);
+                log.error("id={}번 파티 삭제 실패", party.getId());
             }
         }
 

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -1,5 +1,6 @@
 package com.ll.playon.domain.party.party.repository;
 
+import com.ll.playon.domain.chat.entity.PartyRoom;
 import com.ll.playon.domain.game.game.entity.SteamGame;
 import com.ll.playon.domain.game.game.projection.TopPartyGameProjection;
 import com.ll.playon.domain.game.game.projection.TopPlaytimeGameProjection;
@@ -10,6 +11,7 @@ import com.ll.playon.domain.party.party.type.PartyRole;
 import com.ll.playon.domain.party.party.type.PartyStatus;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -192,4 +194,13 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             WHERE p.partyAt < :deadline
             """)
     List<Party> findExpiredPartiesToDelete(@Param("deadline") LocalDateTime deadline);
+
+    @Query("""
+            SELECT p
+            FROM Party p
+            JOIN PartyRoom pr
+            ON pr.party = p
+            WHERE pr = :partyRoom
+            """)
+    Optional<Party> findByPartyRoom(@Param("partyRoom") PartyRoom partyRoom);
 }


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 로그 파일 저장 형식 문제 해결
- 로그 파일이 원하던 형식으로 저장되지 않고, 원하는 메서드에서의 로그만 저장되지 않던 문제 해결

### 2. Lazy Loading 으로 인한 문제 해결
- 기존 `partyRoom.getParty.closeParty()` 메서드에서 `Lazy Loading` 으로 인한 문제 발생
- 새로운 쿼리를 생성해서 직접적으로 `Party` 를 얻어와서 처리함으로 해당 문제 해결