### PR TITLE
[REFACTOR] 게시글 상세조회 프로필 이미지 버그 해결

### DIFF
--- a/src/main/java/com/ll/playon/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/ll/playon/domain/board/repository/BoardRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
 
 @Repository

--- a/src/main/java/com/ll/playon/domain/board/service/BoardService.java
+++ b/src/main/java/com/ll/playon/domain/board/service/BoardService.java
@@ -122,19 +122,19 @@ public class BoardService {
 
     @Transactional(readOnly = true)
     public GetBoardDetailResponse getBoardDetail(long boardId, Member actor) {
-        Board board = findBoardOrElseThrow(boardId);
+        Board board = boardRepository.findByIdWithAuthor(boardId)
+                .orElseThrow(ErrorCode.BOARD_NOT_FOUND::throwServiceException);
 
         // 조회수 증가
         board.increaseHit();
 
         MemberProfileDto authorProfile = memberRepository.getProfile(board.getAuthor().getId())
-                .orElse(MemberProfileDto.builder() // 방어차원..
+                .orElseGet(() -> MemberProfileDto.builder()
                         .memberId(board.getAuthor().getId())
                         .nickname(board.getAuthor().getNickname())
-                        .profileImg("")
-                        .title("")
-                        .build()
-                );
+                        .profileImg(board.getAuthor().getProfileImg())
+                        .title(board.getTitle())
+                        .build());
 
         return GetBoardDetailResponse.builder()
                 .boardId(board.getId())

--- a/src/main/java/com/ll/playon/domain/board/service/BoardService.java
+++ b/src/main/java/com/ll/playon/domain/board/service/BoardService.java
@@ -128,12 +128,14 @@ public class BoardService {
         // 조회수 증가
         board.increaseHit();
 
-        MemberProfileDto authorProfile = memberRepository.getProfile(board.getAuthor().getId())
+        Member author = board.getAuthor(); // fetch join으로 가져옴
+
+        MemberProfileDto authorProfile = memberRepository.getProfile(board.getAuthor().getId()) // title까지 가져오는
                 .orElseGet(() -> MemberProfileDto.builder()
-                        .memberId(board.getAuthor().getId())
-                        .nickname(board.getAuthor().getNickname())
-                        .profileImg(board.getAuthor().getProfileImg())
-                        .title(board.getTitle())
+                        .memberId(author.getId())
+                        .nickname(author.getNickname() != null ? author.getNickname() : author.getUsername())
+                        .profileImg(author.getProfileImg())
+                        .title(null)
                         .build());
 
         return GetBoardDetailResponse.builder()

--- a/src/main/java/com/ll/playon/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ll/playon/domain/member/repository/MemberRepository.java
@@ -21,11 +21,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             SELECT new com.ll.playon.domain.board.dto.MemberProfileDto(
                 m.id,
                 COALESCE(m.nickname, m.username),
-                img.imageUrl,
+                m.profileImg,
                 t.name
             )
             FROM Member m
-            LEFT JOIN Image img ON img.referenceId = m.id AND img.imageType = 'MEMBER'
             LEFT JOIN MemberTitle mt ON mt.member = m AND mt.isRepresentative = true
             LEFT JOIN Title t ON mt.title = t
             WHERE m.id = :memberId


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
- 게시글 상세 조회 최적화 및 N+1 방지
- Board 조회 시 Member Fetch Join 적용
- 대표 칭호 조회는 getProfile 쿼리로 처리
- Lazy Loading 방지 및 불필요한 쿼리 발생 방지
