### PR TITLE
[FIX] 종료된 파티만 가져오는 API로 변경

### DIFF
--- a/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
+++ b/src/main/java/com/ll/playon/domain/party/party/entity/Party.java
@@ -37,7 +37,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
                 @Index(name = "idx_party_status_public_total_max_party_at_created", columnList = "party_status, is_public, total, maximum, party_at, created_at"),
                 @Index(name = "idx_party_public_status_ended_created", columnList = "is_public, party_status, ended_at, created_at"),
                 @Index(name = "idx_party_created_game", columnList = "created_at, game_id"),
-                @Index(name = "idx_party_party_at_status_ended", columnList = "party_at, party_status, ended_at")
+                @Index(name = "idx_party_party_at_status_ended", columnList = "party_at, party_status, ended_at"),
+                @Index(name = "idx_party_status_party_at", columnList = "party_status, party_at")
         }
 )
 @Getter

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -158,7 +158,6 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             FROM PartyMember pm
             WHERE pm.member.id = :memberId
             AND pm.partyRole IN :partyRoles
-            AND pm.party.publicFlag = true
             AND pm.party.partyStatus != :partyStatus
             """)
     List<Party> findMembersActiveParties(@Param("memberId") long memberId,
@@ -170,14 +169,12 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             FROM PartyMember pm
             JOIN pm.party p
             WHERE pm.member.id = :memberId
-            AND p.publicFlag = true
             AND p.partyStatus = :partyStatus
-            AND pm.partyLog IS NOT NULL
             ORDER BY p.endedAt DESC
             """)
-    Page<Party> findMembersRecentCompletedPartiesWithLogs(@Param("memberId") Long memberId,
-                                                          @Param("partyStatus") PartyStatus partyStatus,
-                                                          Pageable pageable);
+    Page<Party> findMembersRecentCompletedParties(@Param("memberId") Long memberId,
+                                                  @Param("partyStatus") PartyStatus partyStatus,
+                                                  Pageable pageable);
 
     @Query("""
             SELECT pm.party


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. API 기능 변경
- 기존 API : 종료된 공개 파티 중 로그가 작성된 것들만 가져오는 API
- 변경 : 종료된 파티를 가져오는 API

- 기존 API : 종료되지 않은 공개 파티를 가져오는 API
- 변경 : 종료된 파티를 가져오는 API