### PR TITLE
[FIX] 유저페이지 파티 및 종료 파티 노출 조건 수정

### DIFF
--- a/src/main/java/com/ll/playon/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/playon/domain/member/service/MemberService.java
@@ -424,7 +424,7 @@ public class MemberService {
                 ));
     }
 
-    // 최근 유저에 의해 로그가 작성된 종료된 파티 조회
+    // 유저가 참여했던 파티들을 최근에 끝난 순으로 조회
     private PageImpl<GetPartyResponse> getCompletedPartiesByMembers(Page<Party> completedParties, Pageable pageable) {
         List<Long> completedPartyIds = completedParties.stream()
                 .map(Party::getId)

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -159,6 +159,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             WHERE pm.member.id = :memberId
             AND pm.partyRole IN :partyRoles
             AND pm.party.partyStatus != :partyStatus
+            ORDER BY pm.party.partyAt ASC
             """)
     List<Party> findMembersActiveParties(@Param("memberId") long memberId,
                                          @Param("partyRoles") List<PartyRole> partyRoles,
@@ -169,6 +170,7 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             FROM PartyMember pm
             JOIN pm.party p
             WHERE pm.member.id = :memberId
+            AND (pm.partyRole = 'OWNER' OR pm.partyRole = 'MEMBER')
             AND p.partyStatus = :partyStatus
             ORDER BY p.endedAt DESC
             """)


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1. 유저페이지 파티 조회 수정
- 참가 신청자, 초대자인 경우에도 종료 파티가 보이는 버그 수정
- 참여 중인 파티를 파티 시작 시간 임박 순으로 정렬